### PR TITLE
NEW: Hard theshold ptycho object magnitude to <= 1.0

### DIFF
--- a/src/tike/ptycho/object.py
+++ b/src/tike/ptycho/object.py
@@ -126,4 +126,8 @@ def get_padded_object(scan, probe):
     height = probe.shape[-1] + int(span[0]) + pad
     width = probe.shape[-1] + int(span[1]) + pad
 
-    return np.ones((height, width), dtype='complex64'), scan
+    return np.full(
+        shape=(height, width),
+        dtype='complex64',
+        fill_value=np.complex64(0.5 + 0j),
+    ), scan

--- a/src/tike/ptycho/object.py
+++ b/src/tike/ptycho/object.py
@@ -42,6 +42,9 @@ class ObjectOptions:
     m: np.array = dataclasses.field(init=False, default_factory=lambda: None)
     """The first moment for adaptive moment."""
 
+    clip_magnitude: bool = True
+    """Whether to force the object magnitude to remain <= 1."""
+
     def copy_to_device(self):
         """Copy to the current GPU memory."""
         if self.v is not None:

--- a/src/tike/ptycho/probe.py
+++ b/src/tike/ptycho/probe.py
@@ -79,10 +79,10 @@ class ProbeOptions:
     probe_support: float = 10.0
     """Weight of the finite probe support constraint; zero or greater."""
 
-    probe_support_radius: float = 0.5 * 0.6
+    probe_support_radius: float = 0.5 * 0.7
     """Radius of finite probe support as fraction of probe grid. [0.0, 0.5]."""
 
-    probe_support_degree: float = 5
+    probe_support_degree: float = 2.5
     """Degree of the supergaussian defining the probe support; zero or greater."""
 
     def copy_to_device(self):

--- a/tests/ptycho/test_probe.py
+++ b/tests/ptycho/test_probe.py
@@ -116,8 +116,8 @@ class TestProbe(unittest.TestCase):
         """Finite probe support penalty function is within expected bounds."""
         penalty = tike.ptycho.probe.finite_probe_support(
             probe=cp.zeros((101, 101)),  # must be odd shaped for min to be 0
-            radius=0.5 * 0.4,
-            degree=1.0,  # must have degree >= 1 for upper bound to be p
+            radius=0.5 * 0.7,
+            degree=2.5,  # must have degree >= 1 for upper bound to be p
             p=2.345,
         )
         try:

--- a/tests/ptycho/test_ptycho.py
+++ b/tests/ptycho/test_ptycho.py
@@ -220,7 +220,11 @@ class TemplatePtychoRecon():
 
     def init_params(self):
         return tike.ptycho.PtychoParameters(
-            psi=np.ones((600, 600), dtype=np.complex64),
+            psi=np.full(
+                (600, 600),
+                dtype=np.complex64,
+                fill_value=np.complex64(0.5 + 0j),
+            ),
             probe=self.probe,
             scan=self.scan,
         )
@@ -576,8 +580,9 @@ def _save_ptycho_result(result, algorithm):
             vmin=-np.pi,
             vmax=np.pi,
         )
-        plt.imsave(
-            f'{fname}/{0}-ampli.png',
+        import tifffile
+        tifffile.imwrite(
+            f'{fname}/{0}-ampli.tiff',
             np.abs(result.psi).astype('float32'),
         )
         _save_probe(fname, result.probe)


### PR DESCRIPTION
This constrains the probe power ambiguity where the probe can
increase in power and have an equivalent solution.

<!--Thank you for opening a pull request!

We appreciate that you care about this project enough to fix it, and we welcome contributions. We will make every effort to review your pull request in a timely manner. Please help us by following the instructions below.
-->

## Purpose
<!--Describe the problem or feature.

Only address one feature per pull request. If the scope of a single pull request is small (less than 400 lines of code), reviewers can understand it more quickly.

Link to any existing Issues. Use the `Closes` keyword if this Pull closes any Issues.
-->
Prevent power creep and ambiguity in the object and probe multiplication by force clipping the object magnitude to less than or equal to 1.

## Approach
<!--Describe how your changes address the problem.

Provide a brief summary of your algorithm(s) here.
-->
I also tried dividing the object and multiplying the probe by the maximum object magnitude each epoch, but this approach did not work well because it caused the ADAM algorithm to diverge.

## Pre-Merge Checklists

### Submitter
- [ ] Write a helpfully descriptive pull request title.
- [ ] Organize changes into logically grouped commits with descriptive commit messages.
- [ ] Document all new functions.
- [ ] Click 'details' on the readthedocs check to view the updated docs.
- [ ] Write tests for new functions or explain why they are not needed.
- [ ] Address any complaints from pep8speaks.

### Reviewer
- [ ] Actually read all of the code.
- [ ] Run the new code yourself; the included tests should make this easy.
- [ ] Write a summary of the changes as you understand them.
- [ ] Thank the submitter.
