### PR TITLE
BUG: constrain variable probes orthogonal

### DIFF
--- a/src/tike/linalg.py
+++ b/src/tike/linalg.py
@@ -56,7 +56,7 @@ def lstsq(a, b, weights=None):
     return x
 
 
-def orthogonalize_gs(x, axis=-1):
+def orthogonalize_gs(x, axis=-1, N=None):
     """Gram-schmidt orthogonalization for complex arrays.
 
     Parameters
@@ -68,6 +68,8 @@ def orthogonalize_gs(x, axis=-1):
         is orthogonalized. If axis is a tuple, then the number of
         orthogonal vectors is the length of the last dimension not included in
         axis. The other dimensions are broadcast.
+    N : int
+        The axis along which to orthogonalize. Other dimensions are broadcast.
     """
     # Find N, the last dimension not included in axis; we iterate over N
     # vectors in the Gram-schmidt algorithm. Dimensions that are not N or
@@ -76,10 +78,12 @@ def orthogonalize_gs(x, axis=-1):
         axis = tuple(a % x.ndim for a in axis)
     except TypeError:
         axis = (axis % x.ndim,)
-    N = x.ndim - 1
-    while N in axis:
-        N -= 1
-    if N < 0:
+    if N is None:
+        N = x.ndim - 1
+        while N in axis:
+            N -= 1
+    N = N % x.ndim
+    if N in axis:
         raise ValueError("Cannot orthogonalize a single vector.")
     # Move axis N to the front for convenience
     x = np.moveaxis(x, N, 0)

--- a/src/tike/ptycho/probe.py
+++ b/src/tike/ptycho/probe.py
@@ -149,6 +149,8 @@ def constrain_variable_probe(variable_probe, weights):
         axis=(-3, -2, -1),
     )
 
+    assert np.all(np.diff(tike.linalg.norm(variable_probe, axis=(-2, -1), keepdims=False), axis=-2) <= 0), "Power of the variable probes should be monotonically decreasing!"
+
     logger.info('Remove outliars from variable probe weights')
     aevol = cp.abs(weights)
     weights = cp.minimum(
@@ -479,7 +481,9 @@ def orthogonalize_eig(x):
     # order, so we just reverse the order of modes to have them sorted in
     # descending order.
     vectors = vectors[..., ::-1].swapaxes(-1, -2)
-    return (vectors @ x.reshape(*x.shape[:-2], -1)).reshape(*x.shape)
+    result = (vectors @ x.reshape(*x.shape[:-2], -1)).reshape(*x.shape)
+    assert np.all(np.diff(tike.linalg.norm(result, axis=(-2, -1), keepdims=False), axis=-1) <= 0), "Power of the orthogonalized probes should be monotonically decreasing!"
+    return result
 
 
 def gaussian(size, rin=0.8, rout=1.0):

--- a/src/tike/ptycho/probe.py
+++ b/src/tike/ptycho/probe.py
@@ -143,6 +143,10 @@ def constrain_variable_probe(variable_probe, weights):
     2. Enforce orthogonality once per epoch
 
     """
+    # NOTE: No smoothing of variable probe weights because the weights are not
+    # stored consecutively in device memory. Smoothing would require sorting
+    # and synchronizing the weights with the host.
+
     logger.info('Orthogonalize variable probes')
     variable_probe = tike.linalg.orthogonalize_gs(
         variable_probe,

--- a/src/tike/ptycho/probe.py
+++ b/src/tike/ptycho/probe.py
@@ -146,10 +146,15 @@ def constrain_variable_probe(variable_probe, weights):
     logger.info('Orthogonalize variable probes')
     variable_probe = tike.linalg.orthogonalize_gs(
         variable_probe,
-        axis=(-3, -2, -1),
+        axis=(-2, -1),
+        N=-4,
     )
 
-    assert np.all(np.diff(tike.linalg.norm(variable_probe, axis=(-2, -1), keepdims=False), axis=-2) <= 0), "Power of the variable probes should be monotonically decreasing!"
+    if __debug__:
+        _power = tike.linalg.norm(variable_probe, axis=(-2, -1), keepdims=False)
+        assert np.all(
+            np.diff(_power, axis=-2) <= 0
+        ), f"Variable probes power should be monotonically decreasing! {_power}"
 
     logger.info('Remove outliars from variable probe weights')
     aevol = cp.abs(weights)
@@ -482,7 +487,10 @@ def orthogonalize_eig(x):
     # descending order.
     vectors = vectors[..., ::-1].swapaxes(-1, -2)
     result = (vectors @ x.reshape(*x.shape[:-2], -1)).reshape(*x.shape)
-    assert np.all(np.diff(tike.linalg.norm(result, axis=(-2, -1), keepdims=False), axis=-1) <= 0), "Power of the orthogonalized probes should be monotonically decreasing!"
+    assert np.all(
+        np.diff(tike.linalg.norm(result, axis=(-2, -1), keepdims=False),
+                axis=-1) <= 0
+    ), "Power of the orthogonalized probes should be monotonically decreasing!"
     return result
 
 

--- a/src/tike/ptycho/solvers/lstsq.py
+++ b/src/tike/ptycho/solvers/lstsq.py
@@ -212,11 +212,11 @@ def lstsq_grad(
                             a=object_options.smoothness_constraint)
 
     if eigen_probe is not None:
-        eigen_probe, eigen_weights = (list(a) for a in zip(*comm.pool.map(
-            tike.ptycho.probe.constrain_variable_probe,
+        eigen_probe, eigen_weights = tike.ptycho.probe.constrain_variable_probe(
+            comm,
             beigen_probe,
             eigen_weights,
-        )))
+        )
 
     algorithm_options.costs.append(cost)
     parameters.probe = probe


### PR DESCRIPTION
<!--Thank you for opening a pull request!

We appreciate that you care about this project enough to fix it, and we welcome contributions. We will make every effort to review your pull request in a timely manner. Please help us by following the instructions below.
-->

## Purpose
<!--Describe the problem or feature.

Only address one feature per pull request. If the scope of a single pull request is small (less than 400 lines of code), reviewers can understand it more quickly.

Link to any existing Issues. Use the `Closes` keyword if this Pull closes any Issues.
-->
Adding some assertions showed that the probe orthogonalization
for variable probes was not correct because the resulting probes
were not sorted by power from most to least.


## Approach
<!--Describe how your changes address the problem.

Provide a brief summary of your algorithm(s) here.
-->
A new parameter for the orthogonalize_gs method allows the
correct probe orthogonalization for these probes and a sorting step is added to sort the probes by their power.

## Pre-Merge Checklists

### Submitter
- [x] Write a helpfully descriptive pull request title.
- [x] Organize changes into logically grouped commits with descriptive commit messages.
- [x] Document all new functions.
- [ ] Click 'details' on the readthedocs check to view the updated docs.
- [x] Write tests for new functions or explain why they are not needed.
- [x] Address any complaints from pep8speaks.

### Reviewer
- [ ] Actually read all of the code.
- [ ] Run the new code yourself; the included tests should make this easy.
- [ ] Write a summary of the changes as you understand them.
- [ ] Thank the submitter.
