### PR TITLE
TST: Refactor MPI enabled ptycho tests to not share devices

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -124,9 +124,9 @@ jobs:
   - script: |
       source activate tike
       export OMPI_MCA_opal_cuda_support=true
-      mpirun -n 2 pytest tests/test_comm.py -vs
-      mpirun -n 2 pytest tests/test_ptycho.py -k TestPtychoRecon -vs
-      mpirun -n 2 pytest tests/test_lamino.py -k bucket -vs
+      mpirun -n 2 pytest tests/test_comm.py -v
+      mpirun -n 2 pytest tests/test_ptycho.py -k PtychoRecon -v
+      mpirun -n 2 pytest tests/test_lamino.py -k bucket -v
     displayName: Run tests with MPI
 
   - task: PublishBuildArtifacts@1

--- a/src/tike/communicators/pool.py
+++ b/src/tike/communicators/pool.py
@@ -250,8 +250,8 @@ class ThreadPool(ThreadPoolExecutor):
 
         """
 
-        def f(worker, buf, stride, s):
-            idx = worker // s * s + (worker + stride) % s
+        def f(worker, id, buf, stride, s):
+            idx = id // s * s + (id + stride) % s
             return cp.add(buf, self._copy_to(x[idx], worker))
 
         if self.num_workers == 1:
@@ -260,7 +260,14 @@ class ThreadPool(ThreadPoolExecutor):
         buff = list(x)
         s = len(x) if s is None else s
         for stride in range(1, s):
-            buff = self.map(f, self.workers, buff, stride=stride, s=s)
+            buff = self.map(
+                f,
+                self.workers,
+                range(self.num_workers),
+                buff,
+                stride=stride,
+                s=s,
+            )
 
         return buff
 

--- a/src/tike/communicators/pool.py
+++ b/src/tike/communicators/pool.py
@@ -222,7 +222,7 @@ class ThreadPool(ThreadPoolExecutor):
 
     def reduce_cpu(self, x: typing.List[cp.array]) -> npt.NDArray:
         """Reduce x by addition from all GPUs to a CPU buffer."""
-        assert len(x) == self.num_workers
+        assert len(x) == self.num_workers, f"{len(x)} should equal {self.num_workers}"
         return np.sum(self.map(self._copy_host, x, self.workers), axis=0)
 
     def reduce_mean(self, x: list, axis, worker=None) -> cp.array:

--- a/src/tike/communicators/pool.py
+++ b/src/tike/communicators/pool.py
@@ -222,7 +222,8 @@ class ThreadPool(ThreadPoolExecutor):
 
     def reduce_cpu(self, x: typing.List[cp.array]) -> npt.NDArray:
         """Reduce x by addition from all GPUs to a CPU buffer."""
-        assert len(x) == self.num_workers, f"{len(x)} should equal {self.num_workers}"
+        assert len(x) <= self.num_workers, (
+            f"{len(x)} work is more than {self.num_workers} workers")
         return np.sum(self.map(self._copy_host, x, self.workers), axis=0)
 
     def reduce_mean(self, x: list, axis, worker=None) -> cp.array:

--- a/src/tike/ptycho/io.py
+++ b/src/tike/ptycho/io.py
@@ -46,7 +46,8 @@ def position_units_to_pixels(
     pixel_per_meter = (
         (detector_pixel_width * detector_pixel_count) /
         (detector_distance * wavelength(photon_energy / 1000) / 100))
-    logger.info("Based on detector distance and photon energy,"
+    logger.info(
+        "Based on detector distance and photon energy,"
         f" reconstruction pixel size will be {1 / pixel_per_meter:.3e} m.")
     return positions * pixel_per_meter
 

--- a/src/tike/ptycho/object.py
+++ b/src/tike/ptycho/object.py
@@ -50,7 +50,7 @@ class ObjectOptions:
     """The magnitude of the illumination used for conditioning the object updates."""
 
     combined_update: np.array = dataclasses.field(init=False,
-                                                 default_factory=lambda: None)
+                                                  default_factory=lambda: None)
     """Used for compact batch updates."""
 
     clip_magnitude: bool = True

--- a/src/tike/ptycho/probe.py
+++ b/src/tike/ptycho/probe.py
@@ -384,6 +384,7 @@ def update_eigen_probe(
 
     return eigen_probe, weights
 
+
 def adjust_probe_power(probe, power=None):
     """Rescale the probes according to given power.
 
@@ -400,9 +401,10 @@ def adjust_probe_power(probe, power=None):
         power = 1.0 / np.arange(1, probe.shape[-3] + 1)
     power = power[..., None, None]
 
-    norm = tike.linalg.norm(probe, axis=(-2,-1), keepdims=True)
+    norm = tike.linalg.norm(probe, axis=(-2, -1), keepdims=True)
     probe *= power * norm[..., 0:1, :, :] / norm
     return probe
+
 
 def add_modes_random_phase(probe, nmodes):
     """Initialize additional probe modes by phase shifting the first mode.

--- a/src/tike/ptycho/solvers/lstsq.py
+++ b/src/tike/ptycho/solvers/lstsq.py
@@ -87,7 +87,7 @@ def lstsq_grad(
                 op=op,
             )
         if comm.use_mpi:
-            preconditioner = comm.pool.Allreduce(preconditioner)
+            preconditioner = comm.Allreduce(preconditioner)
         else:
             preconditioner = comm.pool.allreduce(preconditioner)
         # Use a rolling average of this preconditioner and the previous

--- a/src/tike/ptycho/solvers/options.py
+++ b/src/tike/ptycho/solvers/options.py
@@ -45,6 +45,7 @@ class IterativeOptions(abc.ABC):
     """The number of epochs to consider for convergence monitoring. Set to
     any value less than 2 to disable."""
 
+
 @dataclasses.dataclass
 class AdamOptions(IterativeOptions):
     name: str = dataclasses.field(default='adam_grad', init=False)
@@ -75,6 +76,7 @@ class DmOptions(IterativeOptions):
     num_batch: int = 1
     """The dataset is divided into this number of groups where each group is
     processed simultaneously."""
+
 
 @dataclasses.dataclass
 class RpieOptions(IterativeOptions):

--- a/tests/operators/test_lamino.py
+++ b/tests/operators/test_lamino.py
@@ -58,9 +58,11 @@ class TestLaminoBucket(unittest.TestCase, OperatorTests):
                                  dtype='complex64')
         self.d_name = 'data'
         self.kwargs = {
-            'theta': self.xp.linspace(0, 2 * np.pi, ntheta).astype('float32'),
-            'grid': self.xp.asarray(self.operator._make_grid().reshape(n**3, 3),
-                                    dtype='int16'),
+            'theta':
+                self.xp.linspace(0, 2 * np.pi, ntheta).astype('float32'),
+            'grid':
+                self.xp.asarray(self.operator._make_grid().reshape(n**3, 3),
+                                dtype='int16'),
         }
         print(self.operator)
 

--- a/tests/operators/util.py
+++ b/tests/operators/util.py
@@ -61,10 +61,8 @@ class OperatorTests():
         b = inner_complex(self.m, self.m)
         print()
         # NOTE: Inner product with self is real-only magnitude of self
-        print('<F*Fm, F*Fm> = {:.5g}{:+.5g}j'.format(a.real.item(),
-                                                     0))
-        print('<   m,    m> = {:.5g}{:+.5g}j'.format(b.real.item(),
-                                                     0))
+        print('<F*Fm, F*Fm> = {:.5g}{:+.5g}j'.format(a.real.item(), 0))
+        print('<   m,    m> = {:.5g}{:+.5g}j'.format(b.real.item(), 0))
         self.xp.testing.assert_allclose(a.real, b.real, rtol=1e-5, atol=0)
 
     def test_fwd_time(self):

--- a/tests/ptycho/test_position.py
+++ b/tests/ptycho/test_position.py
@@ -14,7 +14,10 @@ def test_position_join(N=245, num_batch=11):
     np.random.shuffle(indices)
     batches = np.array_split(indices, num_batch)
 
-    opts = tike.ptycho.PositionOptions(scan, use_adaptive_moment=True,)
+    opts = tike.ptycho.PositionOptions(
+        scan,
+        use_adaptive_moment=True,
+    )
 
     optsb = [opts.split(b) for b in batches]
 

--- a/tests/ptycho/test_probe.py
+++ b/tests/ptycho/test_probe.py
@@ -2,6 +2,7 @@ import os
 import unittest
 
 import cupy as cp
+import matplotlib.pyplot as plt
 import numpy as np
 import scipy.io
 import tike.ptycho.probe
@@ -163,6 +164,9 @@ def test_hermite_modes():
         np.rollaxis(inputs['probes'], -1, 0)[None, None, ...],
         12,
     )
+
+    flattened = np.concatenate(result1[0], axis=1)
+    plt.imsave(os.path.join(resultdir, 'hermite.png'), np.abs(flattened))
 
     np.testing.assert_allclose(
         result1,

--- a/tests/ptycho/test_probe.py
+++ b/tests/ptycho/test_probe.py
@@ -165,6 +165,7 @@ def test_hermite_modes():
         12,
     )
 
+    os.makedirs(resultdir, exist_ok=True)
     flattened = np.concatenate(result1[0], axis=1)
     plt.imsave(os.path.join(resultdir, 'hermite.png'), np.abs(flattened))
 

--- a/tests/ptycho/test_ptycho.py
+++ b/tests/ptycho/test_ptycho.py
@@ -279,12 +279,13 @@ class TemplatePtychoRecon():
                 params['parameters'] = tike.ptycho.reconstruct(
                     **params,
                     data=self.data,
-                    num_gpu=tuple(i + base_device for i in range(device_per_rank)),
+                    num_gpu=tuple(
+                        i + base_device for i in range(device_per_rank)),
                     use_mpi=_mpi_size > 1,
                 )
         print()
-        print('\n'.join(
-            f'{c[0]:1.3e}' for c in params['parameters'].algorithm_options.costs))
+        print('\n'.join(f'{c[0]:1.3e}'
+                        for c in params['parameters'].algorithm_options.costs))
         return params['parameters']
 
 

--- a/tests/test_comm.py
+++ b/tests/test_comm.py
@@ -15,7 +15,7 @@ except ModuleNotFoundError:
 
 class TestComm(unittest.TestCase):
 
-    def setUp(self, workers=4):
+    def setUp(self, workers=cp.cuda.runtime.getDeviceCount()//2):
         cp.cuda.device.Device(workers * _mpi_rank).use()
         self.comm = tike.communicators.Comm(
             tuple(i + workers * _mpi_rank for i in range(workers))

--- a/tests/test_comm.py
+++ b/tests/test_comm.py
@@ -15,11 +15,10 @@ except ModuleNotFoundError:
 
 class TestComm(unittest.TestCase):
 
-    def setUp(self, workers=cp.cuda.runtime.getDeviceCount()//2):
+    def setUp(self, workers=cp.cuda.runtime.getDeviceCount() // _mpi_size):
         cp.cuda.device.Device(workers * _mpi_rank).use()
         self.comm = tike.communicators.Comm(
-            tuple(i + workers * _mpi_rank for i in range(workers))
-        )
+            tuple(i + workers * _mpi_rank for i in range(workers)))
         self.xp = self.comm.pool.xp
 
     def test_reduce(self):
@@ -50,7 +49,8 @@ class TestComm(unittest.TestCase):
         def check_correct(result):
             self.xp.testing.assert_array_equal(
                 result,
-                self.xp.arange(10).reshape(2, 5) * self.comm.pool.num_workers * self.comm.mpi.size,
+                self.xp.arange(10).reshape(2, 5) * self.comm.pool.num_workers *
+                self.comm.mpi.size,
             )
             print(result)
 

--- a/tests/test_comm.py
+++ b/tests/test_comm.py
@@ -1,12 +1,25 @@
 import unittest
 
+import cupy as cp
+
 import tike.communicators
+
+try:
+    from mpi4py import MPI
+    _mpi_size = MPI.COMM_WORLD.Get_size()
+    _mpi_rank = MPI.COMM_WORLD.Get_rank()
+except ModuleNotFoundError:
+    _mpi_size = 0
+    _mpi_rank = 0
 
 
 class TestComm(unittest.TestCase):
 
     def setUp(self, workers=4):
-        self.comm = tike.communicators.Comm(workers)
+        cp.cuda.device.Device(workers * _mpi_rank).use()
+        self.comm = tike.communicators.Comm(
+            tuple(i + workers * _mpi_rank for i in range(workers))
+        )
         self.xp = self.comm.pool.xp
 
     def test_reduce(self):
@@ -27,6 +40,21 @@ class TestComm(unittest.TestCase):
         self.xp.testing.assert_array_equal(a, result)
         result = self.comm.Allreduce_reduce(a_list, 'gpu')
         self.xp.testing.assert_array_equal(a, result[0])
+
+    @unittest.skipIf(tike.communicators.MPIComm == None, "MPI is unavailable.")
+    def test_Allreduce_allreduce(self):
+        a = self.xp.arange(10).reshape(2, 5)
+        a_list = self.comm.pool.bcast([a])
+        result = self.comm.Allreduce(a_list)
+
+        def check_correct(result):
+            self.xp.testing.assert_array_equal(
+                result,
+                self.xp.arange(10).reshape(2, 5) * self.comm.pool.num_workers * self.comm.mpi.size,
+            )
+            print(result)
+
+        self.comm.pool.map(check_correct, result)
 
     # TODO: Determine what the correct behavior of scatter should be.
     # def test_scatter(self):

--- a/tests/test_lamino.py
+++ b/tests/test_lamino.py
@@ -69,7 +69,7 @@ try:
     _mpi_rank = MPI.COMM_WORLD.Get_rank()
 except ModuleNotFoundError:
     _mpi_rank = 0
-    _mpi_size = 0
+    _mpi_size = 1
 
 
 class TestLaminoRecon(unittest.TestCase):

--- a/tests/test_opt.py
+++ b/tests/test_opt.py
@@ -1,28 +1,18 @@
 import numpy as np
 import tike.opt
 
+
 class AlgorithmOptionsStub:
+
     def __init__(self, costs, window=5) -> None:
         self.costs = costs
         self.convergence_window = window
 
+
 def test_is_converged():
     assert tike.opt.is_converged(
-        AlgorithmOptionsStub(
-            (np.arange(11) / 1234).tolist(),
-            5
-        )
-    )
+        AlgorithmOptionsStub((np.arange(11) / 1234).tolist(), 5))
     assert tike.opt.is_converged(
-        AlgorithmOptionsStub(
-            (np.zeros(11) / 1234).tolist(),
-            5
-        )
-    )
+        AlgorithmOptionsStub((np.zeros(11) / 1234).tolist(), 5))
     assert not tike.opt.is_converged(
-        AlgorithmOptionsStub(
-            (-np.arange(11) / 1234).tolist(),
-            5
-        )
-    )
-
+        AlgorithmOptionsStub((-np.arange(11) / 1234).tolist(), 5))

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -46,6 +46,7 @@ class TestThreadPool(unittest.TestCase):
     #     a = np.arange(10)
     #     result = self.pool.scatter(a)
 
+
 class TestSoloThreadPool(TestThreadPool):
 
     def setUp(self, workers=1):

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -7,7 +7,7 @@ from tike.communicators import ThreadPool
 
 class TestThreadPool(unittest.TestCase):
 
-    def setUp(self, workers=7):
+    def setUp(self, workers=3):
         self.pool = ThreadPool(workers)
         self.xp = self.pool.xp
 
@@ -33,10 +33,24 @@ class TestThreadPool(unittest.TestCase):
         result = self.pool.gather(np.array_split(a, self.pool.num_workers))
         self.xp.testing.assert_array_equal(a, result)
 
+    def test_reduce_cpu(self):
+        ones = self.pool.map(self.xp.ones, shape=(11, 1, 3))
+        result = self.pool.reduce_cpu(ones)
+        np.testing.assert_array_equal(
+            result,
+            np.ones((11, 1, 3)) * self.pool.num_workers,
+        )
+
     # TODO: Determine what the correct behavior of scatter should be.
     # def test_scatter(self):
     #     a = np.arange(10)
     #     result = self.pool.scatter(a)
+
+class TestSoloThreadPool(TestThreadPool):
+
+    def setUp(self, workers=1):
+        self.pool = ThreadPool(workers)
+        self.xp = self.pool.xp
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--Thank you for opening a pull request!

We appreciate that you care about this project enough to fix it, and we welcome contributions. We will make every effort to review your pull request in a timely manner. Please help us by following the instructions below.
-->

## Purpose
<!--Describe the problem or feature.

Only address one feature per pull request. If the scope of a single pull request is small (less than 400 lines of code), reviewers can understand it more quickly.

Link to any existing Issues. Use the `Closes` keyword if this Pull closes any Issues.
-->
Check that ptychography reconstruction are working properly with multiple MPI ranks.


## Approach
<!--Describe how your changes address the problem.

Provide a brief summary of your algorithm(s) here.
-->
Ran the ptychography tests on MONA with 2 MPI ranks and 4 devices per rank. Uncovered a bug in the MPI code paths when multiple ranks run on the same node.

MPI tests now automatically divide devices on a single node amongst the the ranks instead of reusing the same devices.

## Pre-Merge Checklists

### Submitter
- [x] Write a helpfully descriptive pull request title.
- [x] Organize changes into logically grouped commits with descriptive commit messages.
- [x] Document all new functions.
- [ ] Click 'details' on the readthedocs check to view the updated docs.
- [x] Write tests for new functions or explain why they are not needed.
- [ ] Address any complaints from pep8speaks.

### Reviewer
- [ ] Actually read all of the code.
- [ ] Run the new code yourself; the included tests should make this easy.
- [ ] Write a summary of the changes as you understand them.
- [ ] Thank the submitter.
