### PR TITLE
REF: Optimize patch adjoint operation

### DIFF
--- a/src/tike/operators/cupy/convolution.cu
+++ b/src/tike/operators/cupy/convolution.cu
@@ -45,6 +45,11 @@ _adjoint(float2 *patches, float2 *images, int nimagex, int pi, int ii,
   // clang-format on
 }
 
+// NOTE: Uses the same loop structure for forward and adjoint operations
+// because inverting the loop structure to loop over image pixels instead of
+// patch pixels is much slower. There are many more checks and conditionals in
+// order to avoid atomic operations.
+
 // The kernel should be launched with the following maximum shapes:
 // grid shape = (nscan, nimage, patch_size)
 // block shape = (min(max_thread, patch_size), 1, 1)

--- a/src/tike/operators/cupy/convolution.cu
+++ b/src/tike/operators/cupy/convolution.cu
@@ -8,7 +8,7 @@
 // kernel was launched.
 
 typedef void
-forwardOrAdjoint(float2 *, float2 *, int, int, int, float, float);
+forwardOrAdjoint(float2 *, float2 *, int, int, int, const float[4]);
 
 // Consider the point 0.0 in 1 dimension. The weight distribution should be
 // 0 [[ w = 1.0 ]] 1 [ w = 0.0 ] 2
@@ -16,14 +16,8 @@ forwardOrAdjoint(float2 *, float2 *, int, int, int, float, float);
 // 0 [ ] 1 [ [w = 1 - 0.2] ] 2 [ [w = 0.2] ] 3
 __device__ void
 _forward(float2 *patches, float2 *images, int nimagex, int pi, int ii,
-         float sxf, float syf) {
+         const float w[4]) {
   // clang-format off
-  const float w[4] = {
-    (1.0f - sxf) * (1.0f - syf),
-    (       sxf) * (1.0f - syf),
-    (1.0f - sxf) * (       syf),
-    (       sxf) * (       syf),
-  };
   patches[pi].x = images[ii              ].x * w[0]
                 + images[ii + 1          ].x * w[1]
                 + images[ii     + nimagex].x * w[2]
@@ -37,15 +31,9 @@ _forward(float2 *patches, float2 *images, int nimagex, int pi, int ii,
 
 __device__ void
 _adjoint(float2 *patches, float2 *images, int nimagex, int pi, int ii,
-         float sxf, float syf) {
+         const float w[4]) {
   const float2 tmp = patches[pi];
   // clang-format off
-  const float w[4] = {
-    (1.0f - sxf) * (1.0f - syf),
-    (       sxf) * (1.0f - syf),
-    (1.0f - sxf) * (       syf),
-    (       sxf) * (       syf),
-  };
   atomicAdd(&images[ii              ].x, tmp.x * w[0]);
   atomicAdd(&images[ii              ].y, tmp.y * w[0]);
   atomicAdd(&images[ii + 1          ].y, tmp.y * w[1]);
@@ -67,13 +55,17 @@ _loop_over_patches(
     float2 *patches,     // has shape (nscan, patch_shape, patch_shape)
     const float2 *scan,  // has shape (nimage, nscan)
     int nimage, int nimagey, int nimagex,
-    int nscan,    // the number of positions per images
-    int nrepeat,  // number of times to repeat the patch
-    int patch_shape, int padded_shape) {
+    int nscan,         // the number of positions per images
+    int nrepeat,       // number of times to repeat the patch
+    int patch_shape,   // the width of the valid area of the patch
+    int padded_shape,  // the width of the patch including padding
+    int npatch         // the number of unique patches
+) {
   const int pad = (padded_shape - patch_shape) / 2;
 
   // for each image
   for (int ti = blockIdx.y; ti < nimage; ti += gridDim.y) {
+    const int image_offset = padded_shape * padded_shape * nrepeat * nscan * ti;
     // for each scan position
     for (int ts = blockIdx.x; ts < nscan; ts += gridDim.x) {
       // x,y scan coordinates in image
@@ -84,30 +76,36 @@ _loop_over_patches(
       const float syf = scan[ts + ti * nscan].x - sy;
       assert(1.0f >= sxf && sxf >= 0.0f && 1.0f >= syf && syf >= 0.0f);
 
-      for (int r = 0; r < nrepeat; ++r) {
-        // for x,y coords in patch
-        for (int py = blockIdx.z; py < patch_shape; py += gridDim.z) {
-          if (sy + py < 0 || nimagey <= sy + py) continue;
-          // Only x coodrinate is used in thread block because the max number
-          // of threads on an SM is too small for one patch
-          for (int px = threadIdx.x; px < patch_shape; px += blockDim.x) {
-            if (sx + px < 0 || nimagex <= sx + px) continue;
-            // linear patch index (pi)
-            // clang-format off
-            const int pi = (
-              + pad + px + padded_shape * (pad + py)
-              + padded_shape * padded_shape * (r + nrepeat * (ts + nscan * ti))
-            );
-            // clang-format on
+      // for x,y coords in patch
+      for (int py = blockIdx.z; py < patch_shape; py += gridDim.z) {
+        if (sy + py < 0 || nimagey <= sy + py) continue;
 
-            // image index (ii)
-            const int ii = sx + px + nimagex * (sy + py + nimagey * ti);
+        const float _syf = ((nimagey > sy + py) ? syf : 0.0f);
 
-            // Linear interpolation. Ternary sets trailing pixel weights to
-            // zero when leading pixel is at the edge of the grid.
-            operation(patches, images, nimagex, pi, ii,
-                      ((nimagex > sx + px) ? sxf : 0.0f),
-                      ((nimagey > sy + py) ? syf : 0.0f));
+        // Only x coodrinate is used in thread block because the max number
+        // of threads on an SM is too small for one patch
+        for (int px = threadIdx.x; px < patch_shape; px += blockDim.x) {
+          if (sx + px < 0 || nimagex <= sx + px) continue;
+
+          // linear patch index (pi)
+          const int pi = pad + px + padded_shape * (pad + py) + image_offset;
+          // image index (ii)
+          const int ii = sx + px + nimagex * (sy + py + nimagey * ti);
+
+          // Linear interpolation. Ternary sets trailing pixel weights to
+          // zero when leading pixel is at the edge of the grid.
+          const float _sxf = ((nimagex > sx + px) ? sxf : 0.0f);
+          const float w[4] = {
+              (1.0f - sxf) * (1.0f - syf),
+              (sxf) * (1.0f - syf),
+              (1.0f - sxf) * (syf),
+              (sxf) * (syf),
+          };
+
+          for (int r = 0; r < nrepeat; ++r) {
+            const int r_offset
+                = padded_shape * padded_shape * (r + (nrepeat * ts) % npatch);
+            operation(patches, images, nimagex, pi + r_offset, ii, w);
           }
         }
       }
@@ -120,13 +118,14 @@ fwd_patch(float2 *images, float2 *patches, const float2 *scan, int nimage,
           int nimagey, int nimagex, int nscan, int nrepeat, int patch_shape,
           int padded_shape) {
   _loop_over_patches(_forward, images, patches, scan, nimage, nimagey, nimagex,
-                     nscan, nrepeat, patch_shape, padded_shape);
+                     nscan, nrepeat, patch_shape, padded_shape,
+                     nscan * nrepeat);
 }
 
 extern "C" __global__ void
 adj_patch(float2 *images, float2 *patches, const float2 *scan, int nimage,
           int nimagey, int nimagex, int nscan, int nrepeat, int patch_shape,
-          int padded_shape) {
+          int padded_shape, int npatch) {
   _loop_over_patches(_adjoint, images, patches, scan, nimage, nimagey, nimagex,
-                     nscan, nrepeat, patch_shape, padded_shape);
+                     nscan, nrepeat, patch_shape, padded_shape, npatch);
 }

--- a/src/tike/operators/cupy/convolution.cu
+++ b/src/tike/operators/cupy/convolution.cu
@@ -50,6 +50,9 @@ _adjoint(float2 *patches, float2 *images, int nimagex, int pi, int ii,
 // patch pixels is much slower. There are many more checks and conditionals in
 // order to avoid atomic operations.
 
+// NOTE: nscan is the first grid dimension because it is has a larger maximum
+// (2^31) than the later two (6k).
+
 // The kernel should be launched with the following maximum shapes:
 // grid shape = (nscan, nimage, patch_size)
 // block shape = (min(max_thread, patch_size), 1, 1)

--- a/src/tike/operators/cupy/convolution.cu
+++ b/src/tike/operators/cupy/convolution.cu
@@ -88,6 +88,8 @@ _loop_over_patches(
         // for x,y coords in patch
         for (int py = blockIdx.z; py < patch_shape; py += gridDim.z) {
           if (sy + py < 0 || nimagey <= sy + py) continue;
+          // Only x coodrinate is used in thread block because the max number
+          // of threads on an SM is too small for one patch
           for (int px = threadIdx.x; px < patch_shape; px += blockDim.x) {
             if (sx + px < 0 || nimagex <= sx + px) continue;
             // linear patch index (pi)

--- a/src/tike/operators/cupy/convolution.py
+++ b/src/tike/operators/cupy/convolution.py
@@ -160,12 +160,13 @@ class Convolution(Operator):
         nearplane[..., self.pad:self.end, self.pad:self.end] *= probe.conj()
         if rpie:
             probe_amp = probe * probe.conj()
-            # TODO: Allow this kind of broadcasting inside the patch operator
-            probe_amp = cp.tile(probe_amp, (scan.shape[-2], 1, 1, 1))
+            probe_amp = probe_amp.reshape(
+                (*scan.shape[:-2], -1, *nearplane.shape[-2:])
+                # (..., nscan * nprobe, probe_shape, probe_shape)
+                # (...,         nprobe, probe_shape, probe_shape)
+            )
             probe_amp = self.patch.adj(
-                patches=probe_amp.reshape(
-                    (*scan.shape[:-2], scan.shape[-2] * nearplane.shape[-3],
-                     *nearplane.shape[-2:])),
+                patches=probe_amp,
                 images=self.xp.zeros((*scan.shape[:-2], self.nz, self.n),
                                      dtype='complex64'),
                 positions=scan,

--- a/src/tike/ptycho/solvers/dm.py
+++ b/src/tike/ptycho/solvers/dm.py
@@ -362,9 +362,6 @@ def _get_nearplane_gradients(
                 positions=scan,
             )
             probe_amp = probe[..., 0, m, :, :] * probe[..., 0, m, :, :].conj()
-            # TODO: Allow this kind of broadcasting inside the patch operator
-            if probe_amp.shape[-3] == 1:
-                probe_amp = cp.tile(probe_amp, (scan.shape[-2], 1, 1))
             psi_update_denominator = op.diffraction.patch.adj(
                 patches=probe_amp,
                 images=psi_update_denominator,

--- a/src/tike/ptycho/solvers/lstsq.py
+++ b/src/tike/ptycho/solvers/lstsq.py
@@ -268,9 +268,6 @@ def _psi_preconditioner(psi_update_denominator,
     # object update.
     probe_amp = (unique_probe[..., 0, m, :, :] *
                  unique_probe[..., 0, m, :, :].conj())
-    # TODO: Allow this kind of broadcasting inside the patch operator
-    if probe_amp.shape[-3] == 1:
-        probe_amp = cp.tile(probe_amp, (scan_.shape[-2], 1, 1))
     if psi_update_denominator is None:
         psi_update_denominator = cp.zeros(
             shape=psi.shape,

--- a/src/tike/ptycho/solvers/rpie.py
+++ b/src/tike/ptycho/solvers/rpie.py
@@ -366,9 +366,6 @@ def _get_nearplane_gradients(
                 positions=scan,
             )
             probe_amp = probe[..., 0, m, :, :] * probe[..., 0, m, :, :].conj()
-            # TODO: Allow this kind of broadcasting inside the patch operator
-            if probe_amp.shape[-3] == 1:
-                probe_amp = cp.tile(probe_amp, (scan.shape[-2], 1, 1))
             psi_update_denominator = op.diffraction.patch.adj(
                 patches=probe_amp,
                 images=psi_update_denominator,


### PR DESCRIPTION
<!--Thank you for opening a pull request!

We appreciate that you care about this project enough to fix it, and we welcome contributions. We will make every effort to review your pull request in a timely manner. Please help us by following the instructions below.
-->

## Purpose
<!--Describe the problem or feature.

Only address one feature per pull request. If the scope of a single pull request is small (less than 400 lines of code), reviewers can understand it more quickly.

Link to any existing Issues. Use the `Closes` keyword if this Pull closes any Issues.
-->
Profiled some reconstructions and the patch adjoint kernel was the most time function. I tried to make that kernel faster, but I didn't really make any significant differences. This is just a result of some minor tweaks that I made along the way.

The main outcome of this tweaking was that I added an extra parameter to the kernel that allows for a new kind of broadcasting in order to avoid a memory copy in certain places in the code.

## Approach
<!--Describe how your changes address the problem.

Provide a brief summary of your algorithm(s) here.
-->
I used the CuPy wrapper API for NVProf to generate some timing reports:

```
Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   29.26%  1.05751s      1600  660.94us  624.57us  1.0273ms  adj_patch
                   14.53%  525.20ms      4032  130.26us  1.2800us  760.16us  cupy_multiply__complex64_complex64_complex64
                    6.67%  240.99ms      1152  209.19us  12.160us  1.4604ms  cupy_sum
                    5.98%  216.17ms       320  675.54us  671.29us  692.73us  void vector_fft<unsigned int=128, unsigned int=8, unsigned int=2, unsigned int=32, padding_t=6, twiddle_t=0, loadstore_modifier_t=2, layout_t=0, unsigned int, float>(kernel_arguments_t<unsigned int>)
                    5.95%  215.02ms       320  671.93us  667.45us  852.80us  cupy_true_divide__complex64_complex_complex64

```
The most time was spent on the adjoint patch kernel, so I tried to make it more efficient. When that didn't work, I looked into reducing the number of function calls. This lead me to adjusting the API to allow avoiding calling cp.tile in a few places. This should reduce memory overhead. In a separate PR, I should look into reducing the number of calls to multiplications and sums.

## Pre-Merge Checklists

### Submitter
- [x] Write a helpfully descriptive pull request title.
- [x] Organize changes into logically grouped commits with descriptive commit messages.
- [x] Document all new functions.
- [ ] Click 'details' on the readthedocs check to view the updated docs.
- [x] Write tests for new functions or explain why they are not needed.
- [ ] Address any complaints from pep8speaks.

### Reviewer
- [ ] Actually read all of the code.
- [ ] Run the new code yourself; the included tests should make this easy.
- [ ] Write a summary of the changes as you understand them.
- [ ] Thank the submitter.
