### PR TITLE
REF: Move clustering methods to a single module

### DIFF
--- a/src/tike/cluster.py
+++ b/src/tike/cluster.py
@@ -393,3 +393,23 @@ def _assert_cluster_is_full(labels, c, size):
                                          f'cluster {c} had '
                                          f'{xp.sum(labels == c)} points '
                                          f'when it should have {size}.')
+
+
+def cluster_wobbly_center(*args, **kwargs):
+    import warnings
+    warnings.warn(
+        'tike.random.cluster_wobbly_center is depreacted. '
+        'Use tike.cluster.wobbly_center instead.',
+        DeprecationWarning,
+    )
+    return wobbly_center(*args, **kwargs)
+
+
+def cluster_compact(*args, **kwargs):
+    import warnings
+    warnings.warn(
+        'tike.random.cluster_compact is depreacted. '
+        'Use tike.cluster.compact instead.',
+        DeprecationWarning,
+    )
+    return compact(*args, **kwargs)

--- a/src/tike/cluster.py
+++ b/src/tike/cluster.py
@@ -1,0 +1,395 @@
+import itertools
+import typing
+import logging
+
+import cupy as cp
+import numpy as np
+import numpy.typing as npt
+
+import tike.communicators
+
+logger = logging.getLogger(__name__)
+
+
+def _split(m, x, dtype):
+    return cp.asarray(x[m], dtype=dtype)
+
+
+def by_scan_grid(
+    pool: tike.communicators.ThreadPool,
+    shape: typing.Tuple[int],
+    dtype: typing.List[npt.DTypeLike],
+    scan: npt.NDArray[np.float32],
+    *args,
+    fly: int = 1,
+):
+    """Split the field of view into a 2D grid.
+
+    Mask divide the data into a 2D grid of spatially contiguous regions.
+
+    Parameters
+    ----------
+    shape : tuple of int
+        The number of grid divisions along each dimension.
+    dtype : List[str]
+        The datatypes of the args after splitting.
+    scan : (nscan, 2) float32
+        The 2D coordinates of the scan positions.
+    args : (nscan, ...) float32 or None
+        The arrays to be split by scan position.
+    fly : int
+        The number of scan positions per frame.
+
+    Returns
+    -------
+    order : List[array[int]]
+        The locations of the inputs in the original arrays.
+    scan : List[array[float32]]
+        The divided 2D coordinates of the scan positions.
+    args : List[array[float32]] or None
+        Each input divided into regions or None if arg was None.
+
+    """
+    if len(shape) != 2:
+        raise ValueError('The grid shape must have two dimensions.')
+    vstripes = by_scan_stripes(scan, shape[0], axis=0, fly=fly)
+    hstripes = by_scan_stripes(scan, shape[1], axis=1, fly=fly)
+    mask = [
+        np.logical_and(*pair) for pair in itertools.product(vstripes, hstripes)
+    ]
+
+    order = np.arange(scan.shape[-2])
+    order = [order[m] for m in mask]
+
+    split_args = []
+    for arg, t in zip([scan, *args], dtype):
+        if arg is None:
+            split_args.append(None)
+        else:
+            split_args.append(pool.map(_split, mask, x=arg, dtype=t))
+
+    return (order, *split_args)
+
+
+def by_scan_stripes(
+    scan,
+    n: int,
+    fly: int = 1,
+    axis: int = 0,
+) -> typing.List[npt.NDArray[bool]]:
+    """Return `n` boolean masks that split the field of view into stripes.
+
+    Mask divide the data into spatially contiguous regions along the position
+    axis.
+
+    Split scan into three stripes:
+    >>> [scan[s] for s in by_scan_stripes(scan, 3)]
+
+    FIXME: Only uses the first view to divide the positions. Assumes the
+    positions on all angles are distributed similarly.
+
+    Parameters
+    ----------
+    scan : (nscan, 2) float32
+        The 2D coordinates of the scan positions.
+    n : int
+        The number of stripes.
+    fly : int
+        The number of scan positions per frame.
+    axis : int (0 or 1)
+        Which spatial dimension to divide along. i.e. horizontal or vertical.
+
+    Returns
+    -------
+    mask : list of (nscan, ) boolean
+        A list of boolean arrays which divide the scan positions into `n`
+        stripes.
+
+    """
+    if scan.ndim != 2:
+        raise ValueError('scan must have two dimensions.')
+    if n < 1:
+        raise ValueError('The number of stripes must be > 0.')
+
+    nscan, _ = scan.shape
+    if (nscan // fly) * fly != nscan:
+        raise ValueError('The number of scan positions must be an '
+                         'integer multiple of the number of fly positions.')
+
+    # Reshape scan so positions in the same fly scan are not separated
+    scan = scan.reshape(nscan // fly, fly, 2)
+
+    # Determine the edges of the horizontal stripes
+    edges = np.linspace(
+        scan[..., axis].min(),
+        scan[..., axis].max(),
+        n + 1,
+        endpoint=True,
+    )
+
+    # Move the outer edges to include all points
+    edges[0] -= 1
+    edges[-1] += 1
+
+    # Generate masks which put points into stripes
+    return [
+        np.logical_and(
+            edges[i] < scan[:, 0, axis],
+            scan[:, 0, axis] <= edges[i + 1],
+        ).repeat(fly) for i in range(n)
+    ]
+
+
+def wobbly_center(population, num_cluster):
+    """Return the indices that divide population into heterogenous clusters.
+
+    Uses a contrarian approach to clustering by maximizing the heterogeneity
+    inside each cluster to ensure that each cluster would be able to capture
+    the entire variance of the original population yielding clusters which are
+    similar to each other in excess to the original population itself.
+
+    Parameters
+    ----------
+    population : (M, N) array_like
+        The M samples of an N dimensional population that needs to be clustered.
+    num_cluster : int (0..M]
+        The number of clusters in which to divide M samples.
+
+    Returns
+    -------
+    indicies : (num_cluster,) list of array of integer
+        The indicies of population that belong to each cluster.
+
+    Raises
+    ------
+    ValueError
+        If num_cluster is less than 1 or more than 65535. The implementation
+        uses uint16 as cluster tag, so it cannot count more than that number of
+        clusters.
+
+    References
+    ----------
+    Mishra, Megha, Chandrasekaran Anirudh Bhardwaj, and Kalyani Desikan. "A
+    Maximal Heterogeneity Based Clustering Approach for Obtaining Samples."
+    arXiv preprint arXiv:1709.01423 (2017).
+
+    """
+    logger.info("Clustering method is wobbly center.")
+    xp = cp.get_array_module(population)
+    if num_cluster == 1 or num_cluster == population.shape[0]:
+        return xp.split(xp.arange(population.shape[0]), num_cluster)
+    if not 0 < num_cluster <= min(0xFFFF, population.shape[0]):
+        raise ValueError(
+            f"The number of clusters must be 0 < {num_cluster} < min(65536, M)."
+        )
+    # Start with the num_cluster observations closest to the global centroid
+    starting_centroids = xp.argpartition(
+        xp.linalg.norm(population - xp.mean(population, axis=0, keepdims=True),
+                       axis=1),
+        num_cluster,
+        axis=0,
+    )[:num_cluster]
+    # Use a label array to keep track of cluster assignment
+    UNASSIGNED = 0xFFFF
+    labels = xp.full(len(population), UNASSIGNED, dtype='uint16')
+    labels[starting_centroids] = range(num_cluster)
+    # print(f"\nStart with labels: {labels}")
+    for c in range(len(population) - len(starting_centroids)):
+        # c is the label of the cluster getting the next addition
+        c = c % num_cluster
+        # add the unclaimed observation that is furthest from this cluster
+        furthest = xp.argmax(
+            xp.linalg.norm(
+                population[labels == UNASSIGNED] -
+                xp.mean(population[labels == c], axis=0, keepdims=True),
+                axis=1,
+            ),
+            axis=0,
+        )
+        # i is the index of furthest in labels
+        i = xp.argmax(xp.cumsum(labels == UNASSIGNED) == (furthest + 1))
+        # print(f"{i} will be added to {c}")
+        labels[i] = c
+        # print(f"Start with labels: {labels}")
+    return [xp.flatnonzero(labels == c) for c in range(num_cluster)]
+
+
+def compact(population, num_cluster, max_iter=500):
+    """Return the indices that divide population into compact clusters.
+
+    Uses an approach that is inspired by the naive k-means algorithm, but it
+    returns equally sized clusters.
+
+    Parameters
+    ----------
+    population : (M, N) array_like
+        The M samples of an N dimensional population that needs to be clustered.
+    num_cluster : int (0..M]
+        The number of clusters in which to divide M samples.
+
+    Returns
+    -------
+    indicies : (num_cluster,) list of array of integer
+        The indicies of population that belong to each cluster.
+
+    Raises
+    ------
+    ValueError
+        If num_cluster is less than 1 or more than 65535. The implementation
+        uses uint16 as cluster tag, so it cannot count more than that number of
+        clusters.
+
+    """
+    logger.info("Clustering method is compact.")
+    # Indexing and serial operations is very slow on GPU, so always use host
+    population = cp.asnumpy(population)
+    if num_cluster == 1 or num_cluster == population.shape[0]:
+        return np.split(np.arange(population.shape[0]), num_cluster)
+    if not 0 < num_cluster <= min(0xFFFF, population.shape[0]):
+        raise ValueError(
+            f"The number of clusters must be 0 < {num_cluster} < min(65536, M)."
+        )
+    # Define a constant array used for indexing.
+    _all = np.arange(len(population))
+    # Specify the number of points allowed in each cluster
+    size = np.zeros(num_cluster, dtype='int')
+    max_size = np.full(num_cluster, len(population) // num_cluster)
+    max_size[:len(population) % num_cluster] += 1
+
+    # Use kmeans++ to choose initial cluster centers
+    starting_centroids = np.zeros(num_cluster, dtype='int')
+    starting_centroids[0] = np.random.choice(_all, size=1, p=None)[0]
+    distances = np.inf
+    for c in range(1, num_cluster):
+        distances = np.minimum(
+            distances,
+            np.linalg.norm(
+                population - population[starting_centroids[c - 1]],
+                axis=1,
+            )**2,
+        )
+        starting_centroids[c] = np.random.choice(
+            _all,
+            size=1,
+            p=distances / distances.sum(),
+        )[0]
+    centroids = population[starting_centroids]
+
+    # Use a label array to keep track of cluster assignment
+    UNASSIGNED = 0xFFFF
+    labels = np.full(len(population), UNASSIGNED, dtype='uint16')
+
+    # Add all points to initial clusters
+    distances = np.empty((len(population), num_cluster))
+    unfilled_clusters = list(range(num_cluster))
+    _unassigned = list(range(len(population)))
+    for c in unfilled_clusters:
+        distances[:, c] = np.linalg.norm(centroids[c] - population, axis=1)
+        p = starting_centroids[c]
+        labels[p] = c
+        _unassigned.remove(p)
+        size[c] += 1
+    while unfilled_clusters:
+        nearest = np.array(unfilled_clusters)[np.argmin(
+            distances[:, unfilled_clusters],
+            axis=1,
+        )]
+        farthest = np.array(unfilled_clusters)[np.argmax(
+            distances[:, unfilled_clusters],
+            axis=1,
+        )]
+        priority = np.array(_unassigned)[np.argsort(
+            (distances[_all, nearest] -
+             distances[_all, farthest])[_unassigned])]
+        for p in priority:
+            assert labels[p] == UNASSIGNED
+            labels[p] = nearest[p]
+            _unassigned.remove(p)
+            assert size[nearest[p]] < max_size[nearest[p]]
+            size[nearest[p]] += 1
+            if size[nearest[p]] == max_size[nearest[p]]:
+                unfilled_clusters.remove(nearest[p])
+                # re-start with one less available cluster
+                break
+
+    if __debug__:
+        old_objective = _k_means_objective(population, labels, num_cluster)
+
+    # Swap points between clusters to minimize objective
+    for _ in range(max_iter):
+        any_were_swapped = False
+        # Determine distance from each point to each cluster
+        for c in range(num_cluster):
+            distances[:, c] = np.linalg.norm(centroids[c] - population, axis=1)
+        # Determine if each point would be happier in another cluster.
+        # Negative happiness is bad; zero is optimal.
+        labels_wanted = np.argmin(distances, axis=1)
+        happiness = distances[_all, labels_wanted] - distances[_all, labels]
+        # Starting from the least happy point, swap points between groups to
+        # improve net happiness
+        for p in np.argsort(happiness):
+            if happiness[p] < 0:
+                # Compute the change in happiness from swapping this point with
+                # every other point
+                net_happiness = (
+                    + distances[p, labels[p]]
+                    + distances[_all, labels]
+                    - distances[p, labels]
+                    - distances[_all, labels[p]]
+                )  # yapf: disable
+                good_swaps = np.flatnonzero(
+                    np.logical_and(
+                        # only want swaps that improve happiness
+                        net_happiness > 0,
+                        # swapping within a cluster has no effect
+                        labels != labels[p],
+                    ))
+                if good_swaps.size > 0:
+                    any_were_swapped = True
+                    o = good_swaps[np.argmax(net_happiness[good_swaps])]
+                    assert labels[p] != labels[
+                        o], 'swapping within a cluster has no effect!'
+                    labels[o], labels[p] = labels[p], labels[o]
+                    happiness[o] = distances[o, labels_wanted[o]] - distances[
+                        o, labels[o]]
+                    happiness[p] = distances[p, labels_wanted[p]] - distances[
+                        p, labels[p]]
+        if not any_were_swapped:
+            break
+        elif __debug__:
+            objective = _k_means_objective(population, labels, num_cluster)
+            # print(f"{objective:e}")
+            # NOTE: Assertion disabled because happiness metric is heuristic
+            # approximation of k-means objective
+            # assert old_objective >= objective, (old_objective, objective)
+            old_objective = objective
+
+        # compute new cluster centroids
+        for c in range(num_cluster):
+            centroids[c] = np.mean(population[labels == c], axis=0)
+
+    if __debug__:
+        for c in range(num_cluster):
+            _assert_cluster_is_full(labels, c, max_size[c])
+    return [np.flatnonzero(labels == c) for c in range(num_cluster)]
+
+
+def _k_means_objective(population, labels, num_cluster):
+    """Return the weighted sum of the generalized variance of each cluster."""
+    xp = cp.get_array_module(population)
+    cost = 0
+    for c in range(num_cluster):
+        cost += xp.sum(labels == c) * xp.linalg.det(
+            xp.cov(
+                population[labels == c],
+                rowvar=False,
+            ))
+    return cost
+
+
+def _assert_cluster_is_full(labels, c, size):
+    xp = cp.get_array_module(labels)
+    assert size == np.sum(labels == c), ('All clusters should be full, but '
+                                         f'cluster {c} had '
+                                         f'{xp.sum(labels == c)} points '
+                                         f'when it should have {size}.')

--- a/src/tike/ptycho/ptycho.py
+++ b/src/tike/ptycho/ptycho.py
@@ -57,7 +57,6 @@ __all__ = [
 ]
 
 import copy
-from itertools import product
 import logging
 import time
 import typing
@@ -70,7 +69,7 @@ from tike.operators import Ptycho
 from tike.communicators import Comm, MPIComm
 import tike.opt
 from tike.ptycho import solvers
-import tike.random
+import tike.cluster
 
 from .position import (
     PositionOptions,
@@ -344,7 +343,7 @@ class Reconstruction():
             self._device_parameters.scan,
             self.data,
             self._device_parameters.eigen_weights,
-        ) = split_by_scan_grid(
+        ) = tike.cluster.by_scan_grid(
             self.comm.pool,
             (
                 self.comm.pool.num_workers
@@ -385,7 +384,7 @@ class Reconstruction():
 
         # Unique batch for each device
         self.batches = self.comm.pool.map(
-            getattr(tike.random,
+            getattr(tike.cluster,
                     self._device_parameters.algorithm_options.batch_method),
             self._device_parameters.scan,
             num_cluster=self._device_parameters.algorithm_options.num_batch,
@@ -576,7 +575,7 @@ class Reconstruction():
             order,
             new_scan,
             new_data,
-        ) = split_by_scan_grid(
+        ) = tike.cluster.by_scan_grid(
             self.comm.pool,
             (
                 self.comm.pool.num_workers
@@ -609,7 +608,7 @@ class Reconstruction():
 
         # Rebatch on each device
         self.batches = self.comm.pool.map(
-            getattr(tike.random,
+            getattr(tike.cluster,
                     self._device_parameters.algorithm_options.batch_method),
             self._device_parameters.scan,
             num_cluster=self._device_parameters.algorithm_options.num_batch,
@@ -694,120 +693,6 @@ def _rescale_probe(operator, comm, data, psi, scan, probe, num_batch):
     probe[0] *= rescale
 
     return comm.pool.bcast([probe[0]])
-
-
-def _split(m, x, dtype):
-    return cp.asarray(x[m], dtype=dtype)
-
-
-def split_by_scan_grid(pool, shape, dtype, scan, *args, fly=1):
-    """Split the field of view into a 2D grid.
-
-    Mask divide the data into a 2D grid of spatially contiguous regions.
-
-    Parameters
-    ----------
-    shape : tuple of int
-        The number of grid divisions along each dimension.
-    dtype : List[str]
-        The datatypes of the args after splitting.
-    scan : (nscan, 2) float32
-        The 2D coordinates of the scan positions.
-    args : (nscan, ...) float32 or None
-        The arrays to be split by scan position.
-    fly : int
-        The number of scan positions per frame.
-
-    Returns
-    -------
-    order : List[array[int]]
-        The locations of the inputs in the original arrays.
-    scan : List[array[float32]]
-        The divided 2D coordinates of the scan positions.
-    args : List[array[float32]] or None
-        Each input divided into regions or None if arg was None.
-    """
-    if len(shape) != 2:
-        raise ValueError('The grid shape must have two dimensions.')
-    vstripes = split_by_scan_stripes(scan, shape[0], axis=0, fly=fly)
-    hstripes = split_by_scan_stripes(scan, shape[1], axis=1, fly=fly)
-    mask = [np.logical_and(*pair) for pair in product(vstripes, hstripes)]
-
-    order = np.arange(scan.shape[-2])
-    order = [order[m] for m in mask]
-
-    split_args = []
-    for arg, t in zip([scan, *args], dtype):
-        if arg is None:
-            split_args.append(None)
-        else:
-            split_args.append(pool.map(_split, mask, x=arg, dtype=t))
-
-    return (order, *split_args)
-
-
-def split_by_scan_stripes(scan, n, fly=1, axis=0):
-    """Return `n` boolean masks that split the field of view into stripes.
-
-    Mask divide the data into spatially contiguous regions along the position
-    axis.
-
-    Split scan into three stripes:
-    >>> [scan[s] for s in split_by_scan_stripes(scan, 3)]
-
-    FIXME: Only uses the first view to divide the positions. Assumes the
-    positions on all angles are distributed similarly.
-
-    Parameters
-    ----------
-    scan : (nscan, 2) float32
-        The 2D coordinates of the scan positions.
-    n : int
-        The number of stripes.
-    fly : int
-        The number of scan positions per frame.
-    axis : int (0 or 1)
-        Which spatial dimension to divide along. i.e. horizontal or vertical.
-
-    Returns
-    -------
-    mask : list of (nscan, ) boolean
-        A list of boolean arrays which divide the scan positions into `n`
-        stripes.
-
-    """
-    if scan.ndim != 2:
-        raise ValueError('scan must have two dimensions.')
-    if n < 1:
-        raise ValueError('The number of stripes must be > 0.')
-
-    nscan, _ = scan.shape
-    if (nscan // fly) * fly != nscan:
-        raise ValueError('The number of scan positions must be an '
-                         'integer multiple of the number of fly positions.')
-
-    # Reshape scan so positions in the same fly scan are not separated
-    scan = scan.reshape(nscan // fly, fly, 2)
-
-    # Determine the edges of the horizontal stripes
-    edges = np.linspace(
-        scan[..., axis].min(),
-        scan[..., axis].max(),
-        n + 1,
-        endpoint=True,
-    )
-
-    # Move the outer edges to include all points
-    edges[0] -= 1
-    edges[-1] += 1
-
-    # Generate masks which put points into stripes
-    return [
-        np.logical_and(
-            edges[i] < scan[:, 0, axis],
-            scan[:, 0, axis] <= edges[i + 1],
-        ).repeat(fly) for i in range(n)
-    ]
 
 
 def reconstruct_multigrid(

--- a/src/tike/ptycho/solvers/lstsq.py
+++ b/src/tike/ptycho/solvers/lstsq.py
@@ -106,7 +106,7 @@ def lstsq_grad(
                 [2] * comm.pool.num_workers,
             )
 
-        if algorithm_options.batch_method == 'cluster_compact':
+        if algorithm_options.batch_method == 'compact':
             object_options.combined_update = cp.zeros_like(psi[0])
 
     batch_cost = []
@@ -207,7 +207,7 @@ def lstsq_grad(
             n=n,
         )
 
-    if object_options and algorithm_options.batch_method == 'cluster_compact':
+    if object_options and algorithm_options.batch_method == 'compact':
         # (27b) Object update
         dpsi = object_options.combined_update
         if object_options.use_adaptive_moment:
@@ -498,7 +498,7 @@ def _update_nearplane(
             dpsi = (weighted_step_psi[0] /
                     probe[0].shape[-3]) * common_grad_psi[0]
 
-            if algorithm_options.batch_method != 'cluster_compact':
+            if algorithm_options.batch_method != 'compact':
                 if object_options.use_adaptive_moment:
                     (
                         dpsi,
@@ -518,7 +518,7 @@ def _update_nearplane(
 
         if recover_probe:
             dprobe = weighted_step_probe[0] * common_grad_probe[0]
-            if algorithm_options.batch_method == 'cluster_compact':
+            if algorithm_options.batch_method == 'compact':
                 dprobe /= len(scan_)
             if probe_options.use_adaptive_moment:
                 if probe_options.m is None:

--- a/src/tike/ptycho/solvers/options.py
+++ b/src/tike/ptycho/solvers/options.py
@@ -24,9 +24,9 @@ class IterativeOptions(abc.ABC):
     """The dataset is divided into this number of groups where each group is
     processed sequentially."""
 
-    batch_method: str = 'cluster_wobbly_center'
+    batch_method: str = 'wobbly_center'
     """The name of the batch selection method. Choose from the cluster methods
-    in the tike.random module."""
+    in the tike.cluster module."""
 
     costs: typing.List[typing.List[float]] = dataclasses.field(
         init=False,

--- a/src/tike/random.py
+++ b/src/tike/random.py
@@ -5,7 +5,6 @@ import logging
 import cupy as cp
 import numpy as np
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -19,254 +18,23 @@ def cupy_complex(*shape):
     return (cp.random.rand(*shape, 2) - 0.5).view('complex')[..., 0]
 
 
-def cluster_wobbly_center(population, num_cluster):
-    """Return the indices that divide population into heterogenous clusters.
-
-    Uses a contrarian approach to clustering by maximizing the heterogeneity
-    inside each cluster to ensure that each cluster would be able to capture
-    the entire variance of the original population yielding clusters which are
-    similar to each other in excess to the original population itself.
-
-    Parameters
-    ----------
-    population : (M, N) array_like
-        The M samples of an N dimensional population that needs to be clustered.
-    num_cluster : int (0..M]
-        The number of clusters in which to divide M samples.
-
-    Returns
-    -------
-    indicies : (num_cluster,) list of array of integer
-        The indicies of population that belong to each cluster.
-
-    Raises
-    ------
-    ValueError
-        If num_cluster is less than 1 or more than 65535. The implementation
-        uses uint16 as cluster tag, so it cannot count more than that number of
-        clusters.
-
-    References
-    ----------
-    Mishra, Megha, Chandrasekaran Anirudh Bhardwaj, and Kalyani Desikan. "A
-    Maximal Heterogeneity Based Clustering Approach for Obtaining Samples."
-    arXiv preprint arXiv:1709.01423 (2017).
-    """
-    logger.info("Clustering method is wobbly center.")
-    xp = cp.get_array_module(population)
-    if num_cluster == 1 or num_cluster == population.shape[0]:
-        return xp.split(xp.arange(population.shape[0]), num_cluster)
-    if not 0 < num_cluster <= min(0xFFFF, population.shape[0]):
-        raise ValueError(
-            f"The number of clusters must be 0 < {num_cluster} < min(65536, M)."
-        )
-    # Start with the num_cluster observations closest to the global centroid
-    starting_centroids = xp.argpartition(
-        xp.linalg.norm(population - xp.mean(population, axis=0, keepdims=True),
-                       axis=1),
-        num_cluster,
-        axis=0,
-    )[:num_cluster]
-    # Use a label array to keep track of cluster assignment
-    UNASSIGNED = 0xFFFF
-    labels = xp.full(len(population), UNASSIGNED, dtype='uint16')
-    labels[starting_centroids] = range(num_cluster)
-    # print(f"\nStart with labels: {labels}")
-    for c in range(len(population) - len(starting_centroids)):
-        # c is the label of the cluster getting the next addition
-        c = c % num_cluster
-        # add the unclaimed observation that is furthest from this cluster
-        furthest = xp.argmax(
-            xp.linalg.norm(
-                population[labels == UNASSIGNED] -
-                xp.mean(population[labels == c], axis=0, keepdims=True),
-                axis=1,
-            ),
-            axis=0,
-        )
-        # i is the index of furthest in labels
-        i = xp.argmax(xp.cumsum(labels == UNASSIGNED) == (furthest + 1))
-        # print(f"{i} will be added to {c}")
-        labels[i] = c
-        # print(f"Start with labels: {labels}")
-    return [xp.flatnonzero(labels == c) for c in range(num_cluster)]
+def cluster_wobbly_center(*args, **kwargs):
+    import warnings
+    warnings.warn(
+        'tike.random.cluster_wobbly_center is depreacted. '
+        'Use tike.cluster.wobbly_center instead.',
+        DeprecationWarning,
+    )
+    import tike.cluster
+    return tike.cluster.wobbly_center(*args, **kwargs)
 
 
-def cluster_compact(population, num_cluster, max_iter=500):
-    """Return the indices that divide population into compact clusters.
-
-    Uses an approach that is inspired by the naive k-means algorithm, but it
-    returns equally sized clusters.
-
-    Parameters
-    ----------
-    population : (M, N) array_like
-        The M samples of an N dimensional population that needs to be clustered.
-    num_cluster : int (0..M]
-        The number of clusters in which to divide M samples.
-
-    Returns
-    -------
-    indicies : (num_cluster,) list of array of integer
-        The indicies of population that belong to each cluster.
-
-    Raises
-    ------
-    ValueError
-        If num_cluster is less than 1 or more than 65535. The implementation
-        uses uint16 as cluster tag, so it cannot count more than that number of
-        clusters.
-    """
-    logger.info("Clustering method is compact.")
-    # Indexing and serial operations is very slow on GPU, so always use host
-    population = cp.asnumpy(population)
-    if num_cluster == 1 or num_cluster == population.shape[0]:
-        return np.split(np.arange(population.shape[0]), num_cluster)
-    if not 0 < num_cluster <= min(0xFFFF, population.shape[0]):
-        raise ValueError(
-            f"The number of clusters must be 0 < {num_cluster} < min(65536, M)."
-        )
-    # Define a constant array used for indexing.
-    _all = np.arange(len(population))
-    # Specify the number of points allowed in each cluster
-    size = np.zeros(num_cluster, dtype='int')
-    max_size = np.full(num_cluster, len(population) // num_cluster)
-    max_size[:len(population) % num_cluster] += 1
-
-    # Use kmeans++ to choose initial cluster centers
-    starting_centroids = np.zeros(num_cluster, dtype='int')
-    starting_centroids[0] = np.random.choice(_all, size=1, p=None)[0]
-    distances = np.inf
-    for c in range(1, num_cluster):
-        distances = np.minimum(
-            distances,
-            np.linalg.norm(
-                population - population[starting_centroids[c - 1]],
-                axis=1,
-            )**2,
-        )
-        starting_centroids[c] = np.random.choice(
-            _all,
-            size=1,
-            p=distances / distances.sum(),
-        )[0]
-    centroids = population[starting_centroids]
-
-    # Use a label array to keep track of cluster assignment
-    UNASSIGNED = 0xFFFF
-    labels = np.full(len(population), UNASSIGNED, dtype='uint16')
-
-    # Add all points to initial clusters
-    distances = np.empty((len(population), num_cluster))
-    unfilled_clusters = list(range(num_cluster))
-    _unassigned = list(range(len(population)))
-    for c in unfilled_clusters:
-        distances[:, c] = np.linalg.norm(centroids[c] - population, axis=1)
-        p = starting_centroids[c]
-        labels[p] = c
-        _unassigned.remove(p)
-        size[c] += 1
-    while unfilled_clusters:
-        nearest = np.array(unfilled_clusters)[np.argmin(
-            distances[:, unfilled_clusters],
-            axis=1,
-        )]
-        farthest = np.array(unfilled_clusters)[np.argmax(
-            distances[:, unfilled_clusters],
-            axis=1,
-        )]
-        priority = np.array(_unassigned)[np.argsort(
-            (distances[_all, nearest] -
-             distances[_all, farthest])[_unassigned])]
-        for p in priority:
-            assert labels[p] == UNASSIGNED
-            labels[p] = nearest[p]
-            _unassigned.remove(p)
-            assert size[nearest[p]] < max_size[nearest[p]]
-            size[nearest[p]] += 1
-            if size[nearest[p]] == max_size[nearest[p]]:
-                unfilled_clusters.remove(nearest[p])
-                # re-start with one less available cluster
-                break
-
-    if __debug__:
-        old_objective = _k_means_objective(population, labels, num_cluster)
-
-    # Swap points between clusters to minimize objective
-    for _ in range(max_iter):
-        any_were_swapped = False
-        # Determine distance from each point to each cluster
-        for c in range(num_cluster):
-            distances[:, c] = np.linalg.norm(centroids[c] - population, axis=1)
-        # Determine if each point would be happier in another cluster.
-        # Negative happiness is bad; zero is optimal.
-        labels_wanted = np.argmin(distances, axis=1)
-        happiness = distances[_all, labels_wanted] - distances[_all, labels]
-        # Starting from the least happy point, swap points between groups to
-        # improve net happiness
-        for p in np.argsort(happiness):
-            if happiness[p] < 0:
-                # Compute the change in happiness from swapping this point with
-                # every other point
-                net_happiness = (
-                    + distances[p, labels[p]]
-                    + distances[_all, labels]
-                    - distances[p, labels]
-                    - distances[_all, labels[p]]
-                )  # yapf: disable
-                good_swaps = np.flatnonzero(
-                    np.logical_and(
-                        # only want swaps that improve happiness
-                        net_happiness > 0,
-                        # swapping within a cluster has no effect
-                        labels != labels[p],
-                    ))
-                if good_swaps.size > 0:
-                    any_were_swapped = True
-                    o = good_swaps[np.argmax(net_happiness[good_swaps])]
-                    assert labels[p] != labels[
-                        o], 'swapping within a cluster has no effect!'
-                    labels[o], labels[p] = labels[p], labels[o]
-                    happiness[o] = distances[o, labels_wanted[o]] - distances[
-                        o, labels[o]]
-                    happiness[p] = distances[p, labels_wanted[p]] - distances[
-                        p, labels[p]]
-        if not any_were_swapped:
-            break
-        elif __debug__:
-            objective = _k_means_objective(population, labels, num_cluster)
-            # print(f"{objective:e}")
-            # NOTE: Assertion disabled because happiness metric is heuristic
-            # approximation of k-means objective
-            # assert old_objective >= objective, (old_objective, objective)
-            old_objective = objective
-
-        # compute new cluster centroids
-        for c in range(num_cluster):
-            centroids[c] = np.mean(population[labels == c], axis=0)
-
-    if __debug__:
-        for c in range(num_cluster):
-            _assert_cluster_is_full(labels, c, max_size[c])
-    return [np.flatnonzero(labels == c) for c in range(num_cluster)]
-
-
-def _k_means_objective(population, labels, num_cluster):
-    """Return the weighted sum of the generalized variance of each cluster."""
-    xp = cp.get_array_module(population)
-    cost = 0
-    for c in range(num_cluster):
-        cost += xp.sum(labels == c) * xp.linalg.det(
-            xp.cov(
-                population[labels == c],
-                rowvar=False,
-            ))
-    return cost
-
-
-def _assert_cluster_is_full(labels, c, size):
-    xp = cp.get_array_module(labels)
-    assert size == np.sum(labels == c), ('All clusters should be full, but '
-                                         f'cluster {c} had '
-                                         f'{xp.sum(labels == c)} points '
-                                         f'when it should have {size}.')
+def cluster_compact(*args, **kwargs):
+    import warnings
+    warnings.warn(
+        'tike.random.cluster_compact is depreacted. '
+        'Use tike.cluster.compact instead.',
+        DeprecationWarning,
+    )
+    import tike.cluster
+    return tike.cluster.compact(*args, **kwargs)

--- a/tests/ptycho/test_ptycho.py
+++ b/tests/ptycho/test_ptycho.py
@@ -392,7 +392,7 @@ class TestPtychoRecon(TemplatePtychoRecon, unittest.TestCase):
         params.algorithm_options = tike.ptycho.LstsqOptions(
             num_batch=5,
             num_iter=16,
-            batch_method='cluster_compact',
+            batch_method='compact',
         )
         params.probe_options = ProbeOptions(use_adaptive_moment=True,)
         params.object_options = ObjectOptions(use_adaptive_moment=True,)

--- a/tests/ptycho/test_ptycho.py
+++ b/tests/ptycho/test_ptycho.py
@@ -119,29 +119,6 @@ class TestPtychoUtils(unittest.TestCase):
         psi, scan = tike.ptycho.object.get_padded_object(scan, probe)
         tike.ptycho.check_allowed_positions(scan, psi, probe_shape=probe.shape)
 
-    def test_split_by_scan(self):
-        scan = np.mgrid[0:3, 0:3].reshape(2, -1)
-        scan = np.moveaxis(scan, 0, -1)
-
-        ind = tike.ptycho.ptycho.split_by_scan_stripes(scan, 3, axis=0)
-        split = [scan[i] for i in ind]
-
-        solution = [
-            [[0, 0], [0, 1], [0, 2]],
-            [[1, 0], [1, 1], [1, 2]],
-            [[2, 0], [2, 1], [2, 2]],
-        ]
-        np.testing.assert_equal(split, solution)
-
-        ind = tike.ptycho.ptycho.split_by_scan_stripes(scan, 3, axis=1)
-        split = [scan[i] for i in ind]
-        solution = [
-            [[0, 0], [1, 0], [2, 0]],
-            [[0, 1], [1, 1], [2, 1]],
-            [[0, 2], [1, 2], [2, 2]],
-        ]
-        np.testing.assert_equal(split, solution)
-
 
 class TestPtychoSimulate(unittest.TestCase):
 

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -5,7 +5,7 @@ import numpy as np
 import scipy.stats
 
 from tike.opt import batch_indicies, randomizer
-from tike.random import cluster_wobbly_center, cluster_compact
+from tike.cluster import wobbly_center, compact
 
 
 class ClusterTests():
@@ -46,7 +46,7 @@ class ClusterTests():
 
 class TestWobblyCenter(unittest.TestCase, ClusterTests):
 
-    cluster_method = staticmethod(cluster_wobbly_center)
+    cluster_method = staticmethod(wobbly_center)
 
     def setUp(self, num_pop=500, num_cluster=10):
         """Generates a normally distributed 3D population."""
@@ -67,12 +67,12 @@ class TestWobblyCenter(unittest.TestCase, ClusterTests):
             np.array([0, 5, 8]),
             np.array([1, 6, 7]),
         ]
-        result = cluster_wobbly_center(np.arange(10)[:, None], 3)
+        result = wobbly_center(np.arange(10)[:, None], 3)
         for a, b in zip(references, result):
             np.testing.assert_array_equal(a, b)
 
     def test_same_mean(self):
-        """"Test that wobbly center generates better samples of the population.
+        """Test that wobbly center generates better samples of the population.
 
         In this case 'better' is when the ANOVA test concludes that the samples
         are statistically the same on average. The ANOVA null hypothesis is
@@ -88,7 +88,7 @@ class TestWobblyCenter(unittest.TestCase, ClusterTests):
 
         print('\nwobbly center')
         p0 = print_sample_error(
-            cluster_wobbly_center(self.population, self.num_cluster))
+            wobbly_center(self.population, self.num_cluster))
         print('random sample')
         p1 = print_sample_error(batch_indicies(self.num_pop, self.num_cluster))
 
@@ -98,7 +98,7 @@ class TestWobblyCenter(unittest.TestCase, ClusterTests):
 
 class TestClusterCompact(unittest.TestCase, ClusterTests):
 
-    cluster_method = staticmethod(cluster_compact)
+    cluster_method = staticmethod(compact)
 
     def setUp(self, num_pop=50**2, num_cluster=10):
         """Generates points on a regular grid."""
@@ -132,7 +132,7 @@ class TestClusterCompact(unittest.TestCase, ClusterTests):
 
         print('\ncompact cluster')
         p0 = print_sample_error(
-            cluster_compact(self.population, self.num_cluster))
+            compact(self.population, self.num_cluster))
         print('random sample')
         p1 = print_sample_error(batch_indicies(self.num_pop, self.num_cluster))
 
@@ -144,7 +144,7 @@ class TestClusterCompact(unittest.TestCase, ClusterTests):
         import matplotlib
         matplotlib.use('Agg')
         from matplotlib import pyplot as plt
-        samples = cluster_compact(self.population, self.num_cluster)
+        samples = compact(self.population, self.num_cluster)
         plt.figure()
         for s in samples:
             plt.scatter(self.population[s][:, 0], self.population[s][:, 1])

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -5,7 +5,7 @@ import numpy as np
 import scipy.stats
 
 from tike.opt import batch_indicies, randomizer
-from tike.cluster import wobbly_center, compact
+import tike.cluster
 
 
 class ClusterTests():
@@ -46,7 +46,7 @@ class ClusterTests():
 
 class TestWobblyCenter(unittest.TestCase, ClusterTests):
 
-    cluster_method = staticmethod(wobbly_center)
+    cluster_method = staticmethod(tike.cluster.wobbly_center)
 
     def setUp(self, num_pop=500, num_cluster=10):
         """Generates a normally distributed 3D population."""
@@ -67,7 +67,7 @@ class TestWobblyCenter(unittest.TestCase, ClusterTests):
             np.array([0, 5, 8]),
             np.array([1, 6, 7]),
         ]
-        result = wobbly_center(np.arange(10)[:, None], 3)
+        result = tike.cluster.wobbly_center(np.arange(10)[:, None], 3)
         for a, b in zip(references, result):
             np.testing.assert_array_equal(a, b)
 
@@ -88,7 +88,7 @@ class TestWobblyCenter(unittest.TestCase, ClusterTests):
 
         print('\nwobbly center')
         p0 = print_sample_error(
-            wobbly_center(self.population, self.num_cluster))
+            tike.cluster.wobbly_center(self.population, self.num_cluster))
         print('random sample')
         p1 = print_sample_error(batch_indicies(self.num_pop, self.num_cluster))
 
@@ -98,7 +98,7 @@ class TestWobblyCenter(unittest.TestCase, ClusterTests):
 
 class TestClusterCompact(unittest.TestCase, ClusterTests):
 
-    cluster_method = staticmethod(compact)
+    cluster_method = staticmethod(tike.cluster.compact)
 
     def setUp(self, num_pop=50**2, num_cluster=10):
         """Generates points on a regular grid."""
@@ -132,7 +132,7 @@ class TestClusterCompact(unittest.TestCase, ClusterTests):
 
         print('\ncompact cluster')
         p0 = print_sample_error(
-            compact(self.population, self.num_cluster))
+            tike.cluster.compact(self.population, self.num_cluster))
         print('random sample')
         p1 = print_sample_error(batch_indicies(self.num_pop, self.num_cluster))
 
@@ -144,7 +144,7 @@ class TestClusterCompact(unittest.TestCase, ClusterTests):
         import matplotlib
         matplotlib.use('Agg')
         from matplotlib import pyplot as plt
-        samples = compact(self.population, self.num_cluster)
+        samples = tike.cluster.compact(self.population, self.num_cluster)
         plt.figure()
         for s in samples:
             plt.scatter(self.population[s][:, 0], self.population[s][:, 1])
@@ -153,3 +153,27 @@ class TestClusterCompact(unittest.TestCase, ClusterTests):
         if not os.path.isdir(folder):
             os.makedirs(folder)
         plt.savefig(os.path.join(folder, 'clusters.svg'))
+
+
+def test_split_by_scan():
+    scan = np.mgrid[0:3, 0:3].reshape(2, -1)
+    scan = np.moveaxis(scan, 0, -1)
+
+    ind = tike.cluster.by_scan_stripes(scan, 3, axis=0)
+    split = [scan[i] for i in ind]
+
+    solution = [
+        [[0, 0], [0, 1], [0, 2]],
+        [[1, 0], [1, 1], [1, 2]],
+        [[2, 0], [2, 1], [2, 2]],
+    ]
+    np.testing.assert_equal(split, solution)
+
+    ind = tike.cluster.by_scan_stripes(scan, 3, axis=1)
+    split = [scan[i] for i in ind]
+    solution = [
+        [[0, 0], [1, 0], [2, 0]],
+        [[0, 1], [1, 1], [2, 1]],
+        [[0, 2], [1, 2], [2, 2]],
+    ]
+    np.testing.assert_equal(split, solution)


### PR DESCRIPTION
<!--Thank you for opening a pull request!

We appreciate that you care about this project enough to fix it, and we welcome contributions. We will make every effort to review your pull request in a timely manner. Please help us by following the instructions below.
-->

## Purpose
<!--Describe the problem or feature.

Only address one feature per pull request. If the scope of a single pull request is small (less than 400 lines of code), reviewers can understand it more quickly.

Link to any existing Issues. Use the `Closes` keyword if this Pull closes any Issues.
-->
Collect all of the clustering methods into a single module. This is to prevent circular imports when trying to use these methods inside the ptychography module.


## Approach
<!--Describe how your changes address the problem.

Provide a brief summary of your algorithm(s) here.
-->
I have renamed and moved all of the clustering related functsion into the cluster module. I have dropped the leading words "split" and "cluster" because these are redundant when using the full names of the functions i.e. `tike.cluster.cluster_compact` vs `tike.cluster.compact`.

In order to prevent API breaks, I have added wrapper functions with deprecation warnings for the cluster functions which were in the public API. This includes the `batch_method` parameter in `PtychoParameters`.

## Pre-Merge Checklists

### Submitter
- [x] Write a helpfully descriptive pull request title.
- [x] Organize changes into logically grouped commits with descriptive commit messages.
- [x] Document all new functions.
- [ ] Click 'details' on the readthedocs check to view the updated docs.
- [ ] Write tests for new functions or explain why they are not needed.
- [ ] Address any complaints from pep8speaks.

### Reviewer
- [ ] Actually read all of the code.
- [ ] Run the new code yourself; the included tests should make this easy.
- [ ] Write a summary of the changes as you understand them.
- [ ] Thank the submitter.
