### PR TITLE
NEW: Allow mixed precision operators

### DIFF
--- a/src/tike/operators/cupy/bucket.cu
+++ b/src/tike/operators/cupy/bucket.cu
@@ -1,24 +1,26 @@
 
 // Rotate the 3D point 'p' around the origin.
+template <typename thetaType, typename thetaType3>
 __device__ void
-forward_rotation(float3& p, float ctilt, float stilt, float ctheta,
-                 float stheta) {
-  float x = ctilt * p.x - stilt * p.y;
-  float y = -ctheta * stilt * p.x + ctheta * ctilt * p.y - stheta * p.z;
-  float z = -stheta * stilt * p.x + stheta * ctilt * p.y + ctheta * p.z;
+forward_rotation(thetaType3& p, thetaType ctilt, thetaType stilt,
+                 thetaType ctheta, thetaType stheta) {
+  thetaType x = ctilt * p.x - stilt * p.y;
+  thetaType y = -ctheta * stilt * p.x + ctheta * ctilt * p.y - stheta * p.z;
+  thetaType z = -stheta * stilt * p.x + stheta * ctilt * p.y + ctheta * p.z;
   p.x = x;
   p.y = y;
   p.z = z;
 }
 
 // Rotate the 3D point 'p' around the origin in the reverse direction.
+template <typename thetaType, typename thetaType3>
 __device__ void
-reverse_rotation(float3& p, float ctilt, float stilt, float ctheta,
-                 float stheta) {
+reverse_rotation(thetaType3& p, thetaType ctilt, thetaType stilt,
+                 thetaType ctheta, thetaType stheta) {
   // x unused
   // float x = ctilt * p.x - ctheta * stilt * p.y - stheta * stilt * p.z;
-  float y = stilt * p.x + ctheta * ctilt * p.y + stheta * ctilt * p.z;
-  float z = -stheta * p.y + ctheta * p.z;
+  thetaType y = stilt * p.x + ctheta * ctilt * p.y + stheta * ctilt * p.z;
+  thetaType z = -stheta * p.y + ctheta * p.z;
   // x unused
   // p.x = x;
   p.y = y;
@@ -26,9 +28,11 @@ reverse_rotation(float3& p, float ctilt, float stilt, float ctheta,
 }
 
 // Project the point 'p' onto the plane with the given normal
+template <typename thetaType, typename thetaType3>
 __device__ void
-project_point_to_plane(float3& point, const float3& normal) {
-  float distance = point.x * normal.x + point.y * normal.y + point.z * normal.z;
+project_point_to_plane(thetaType3& point, const thetaType3& normal) {
+  thetaType distance
+      = point.x * normal.x + point.y * normal.y + point.z * normal.z;
   point.x = point.x - distance * normal.x;
   point.y = point.y - distance * normal.y;
   point.z = point.z - distance * normal.z;
@@ -38,17 +42,18 @@ project_point_to_plane(float3& point, const float3& normal) {
 // plane defined by tilt and theta.
 // grid shape (ngrid, 0, 0)
 // block shape (precision, precision, precision)
-extern "C" __global__ void
+template <typename thetaType, typename thetaType3>
+__global__ void
 coordinates_and_weights(const short3* grid, const int ngrid, const float tilt,
-                        const float* theta, const int t, const int precision,
-                        short2* plane_coords) {
+                        const thetaType* theta, const int t,
+                        const int precision, short2* plane_coords) {
   // Compute the normal of the projection plane.
-  float ctilt = cosf(tilt);
-  float stilt = sinf(tilt);
-  float ctheta = cosf(theta[t]);
-  float stheta = sinf(theta[t]);
-  float3 normal = {1.f, 0.f, 0.f};
-  forward_rotation(normal, ctilt, stilt, ctheta, stheta);
+  thetaType ctilt = cosf(tilt);
+  thetaType stilt = sinf(tilt);
+  thetaType ctheta = cosf(theta[t]);
+  thetaType stheta = sinf(theta[t]);
+  thetaType3 normal = {1.f, 0.f, 0.f};
+  forward_rotation<thetaType, thetaType3>(normal, ctilt, stilt, ctheta, stheta);
   // printf("normal is %f, %f, %f\n", normal.x, normal.y, normal.z);
 
   for (int g = blockIdx.x; g < ngrid; g += gridDim.x) {
@@ -59,13 +64,14 @@ coordinates_and_weights(const short3* grid, const int ngrid, const float tilt,
     for (int i = threadIdx.z; i < precision; i += blockDim.z) {
       for (int j = threadIdx.y; j < precision; j += blockDim.y) {
         for (int k = threadIdx.x; k < precision; k += blockDim.x) {
-          float3 point;
+          thetaType3 point;
           point.x = grid[g].x + (i + 0.5f) / precision;
           point.y = grid[g].y + (j + 0.5f) / precision;
           point.z = grid[g].z + (k + 0.5f) / precision;
 
-          project_point_to_plane(point, normal);
-          reverse_rotation(point, ctilt, stilt, ctheta, stheta);
+          project_point_to_plane<thetaType, thetaType3>(point, normal);
+          reverse_rotation<thetaType, thetaType3>(point, ctilt, stilt, ctheta,
+                                                  stheta);
 
           short2* chunk = cluster + k + precision * (j + precision * i);
           chunk->x = floorf(point.y);
@@ -77,37 +83,40 @@ coordinates_and_weights(const short3* grid, const int ngrid, const float tilt,
   }
 }
 
-extern "C" __global__ void
-fwd(float2* data, int t, int datashapex, int datashapey, float weight,
-    const float2* u, int ushapex, int ushapey, int ushapez,
+template <typename dataType>
+__global__ void
+fwd(dataType* data, int t, int datashapex, int datashapey, double weight,
+    const dataType* u, int ushapex, int ushapey, int ushapez,
     const short2* plane_index, const short3* grid_index, int gridshapex,
     int precision) {
   int nchunk = precision * precision * precision;
   for (int g = blockIdx.x; g < gridshapex; g += gridDim.x) {
-    const float2* ui
+    const dataType* ui
         = u + grid_index[g].z
           + ushapez * (grid_index[g].y + ushapey * (grid_index[g].x));
     for (int p = threadIdx.x; p < nchunk; p += blockDim.x) {
       const short2* pi = plane_index + p + g * nchunk;
-      float2* di = data + pi->y + datashapey * (pi->x + datashapex * (t));
+      dataType* di = data + pi->y + datashapey * (pi->x + datashapex * (t));
       atomicAdd(&(di->x), weight * ui->x);
       atomicAdd(&(di->y), weight * ui->y);
     }
   }
 }
 
-extern "C" __global__ void
-adj(const float2* data, int t, int datashapex, int datashapey, float weight,
-    float2* u, int ushapex, int ushapey, int ushapez,  //
+template <typename dataType>
+__global__ void
+adj(const dataType* data, int t, int datashapex, int datashapey, double weight,
+    dataType* u, int ushapex, int ushapey, int ushapez,  //
     const short2* plane_index, const short3* grid_index, int gridshapex,
     int precision) {
   int nchunk = precision * precision * precision;
   for (int g = blockIdx.x; g < gridshapex; g += gridDim.x) {
-    float2* ui = u + grid_index[g].z
-                 + ushapez * (grid_index[g].y + ushapey * (grid_index[g].x));
+    dataType* ui = u + grid_index[g].z
+                   + ushapez * (grid_index[g].y + ushapey * (grid_index[g].x));
     for (int p = threadIdx.x; p < nchunk; p += blockDim.x) {
       const short2* pi = plane_index + p + g * nchunk;
-      const float2* di = data + pi->y + datashapey * (pi->x + datashapex * (t));
+      const dataType* di
+          = data + pi->y + datashapey * (pi->x + datashapex * (t));
       atomicAdd(&(ui->x), weight * di->x);
       atomicAdd(&(ui->y), weight * di->y);
     }

--- a/src/tike/operators/cupy/convolution.cu
+++ b/src/tike/operators/cupy/convolution.cu
@@ -7,15 +7,13 @@
 // Padding areas are untouched and retain whatever values they had before the
 // kernel was launched.
 
-typedef void
-forwardOrAdjoint(float2 *, float2 *, int, int, int, const float[4]);
-
 // Consider the point 0.0 in 1 dimension. The weight distribution should be
 // 0 [[ w = 1.0 ]] 1 [ w = 0.0 ] 2
 // Consider the point 1.2 in 1 dimension. The weight distribution should be
 // 0 [ ] 1 [ [w = 1 - 0.2] ] 2 [ [w = 0.2] ] 3
+template < typename patchType, typename imageType >
 __device__ void
-_forward(float2 *patches, float2 *images, int nimagex, int pi, int ii,
+_forward(patchType *patches, imageType *images, int nimagex, int pi, int ii,
          const float w[4]) {
   // clang-format off
   patches[pi].x = images[ii              ].x * w[0]
@@ -29,10 +27,11 @@ _forward(float2 *patches, float2 *images, int nimagex, int pi, int ii,
   // clang-format on
 }
 
+template < typename patchType, typename imageType >
 __device__ void
-_adjoint(float2 *patches, float2 *images, int nimagex, int pi, int ii,
+_adjoint(patchType *patches, imageType *images, int nimagex, int pi, int ii,
          const float w[4]) {
-  const float2 tmp = patches[pi];
+  const patchType tmp = patches[pi];
   // clang-format off
   atomicAdd(&images[ii              ].x, tmp.x * w[0]);
   atomicAdd(&images[ii              ].y, tmp.y * w[0]);
@@ -56,11 +55,12 @@ _adjoint(float2 *patches, float2 *images, int nimagex, int pi, int ii,
 // The kernel should be launched with the following maximum shapes:
 // grid shape = (nscan, nimage, patch_size)
 // block shape = (min(max_thread, patch_size), 1, 1)
+template < typename patchType, typename imageType >
 __device__ void
 _loop_over_patches(
-    forwardOrAdjoint operation,
-    float2 *images,      // has shape (nimage, nimagey, nimagex)
-    float2 *patches,     // has shape (nscan, patch_shape, patch_shape)
+    void operation(patchType *, imageType *, int, int, int, const float[4]),
+    imageType *images,      // has shape (nimage, nimagey, nimagex)
+    patchType *patches,     // has shape (nscan, patch_shape, patch_shape)
     const float2 *scan,  // has shape (nimage, nscan)
     int nimage, int nimagey, int nimagex,
     int nscan,         // the number of positions per images
@@ -121,19 +121,21 @@ _loop_over_patches(
   }
 }
 
-extern "C" __global__ void
-fwd_patch(float2 *images, float2 *patches, const float2 *scan, int nimage,
+template < typename patchType, typename imageType >
+__global__ void
+fwd_patch(imageType *images, patchType *patches, const float2 *scan, int nimage,
           int nimagey, int nimagex, int nscan, int nrepeat, int patch_shape,
           int padded_shape) {
-  _loop_over_patches(_forward, images, patches, scan, nimage, nimagey, nimagex,
+  _loop_over_patches<patchType, imageType>(_forward<patchType, imageType>, images, patches, scan, nimage, nimagey, nimagex,
                      nscan, nrepeat, patch_shape, padded_shape,
                      nscan * nrepeat);
 }
 
-extern "C" __global__ void
-adj_patch(float2 *images, float2 *patches, const float2 *scan, int nimage,
+template < typename patchType, typename imageType >
+__global__ void
+adj_patch(imageType *images, patchType *patches, const float2 *scan, int nimage,
           int nimagey, int nimagex, int nscan, int nrepeat, int patch_shape,
           int padded_shape, int npatch) {
-  _loop_over_patches(_adjoint, images, patches, scan, nimage, nimagey, nimagex,
+  _loop_over_patches<patchType, imageType>(_adjoint<patchType, imageType>, images, patches, scan, nimage, nimagey, nimagex,
                      nscan, nrepeat, patch_shape, padded_shape, npatch);
 }

--- a/src/tike/operators/cupy/convolution.cu
+++ b/src/tike/operators/cupy/convolution.cu
@@ -11,10 +11,10 @@
 // 0 [[ w = 1.0 ]] 1 [ w = 0.0 ] 2
 // Consider the point 1.2 in 1 dimension. The weight distribution should be
 // 0 [ ] 1 [ [w = 1 - 0.2] ] 2 [ [w = 0.2] ] 3
-template < typename patchType, typename imageType >
+template <typename patchType, typename imageType, typename scanType>
 __device__ void
 _forward(patchType *patches, imageType *images, int nimagex, int pi, int ii,
-         const float w[4]) {
+         const scanType w[4]) {
   // clang-format off
   patches[pi].x = images[ii              ].x * w[0]
                 + images[ii + 1          ].x * w[1]
@@ -27,10 +27,10 @@ _forward(patchType *patches, imageType *images, int nimagex, int pi, int ii,
   // clang-format on
 }
 
-template < typename patchType, typename imageType >
+template <typename patchType, typename imageType, typename scanType>
 __device__ void
 _adjoint(patchType *patches, imageType *images, int nimagex, int pi, int ii,
-         const float w[4]) {
+         const scanType w[4]) {
   const patchType tmp = patches[pi];
   // clang-format off
   atomicAdd(&images[ii              ].x, tmp.x * w[0]);
@@ -55,13 +55,13 @@ _adjoint(patchType *patches, imageType *images, int nimagex, int pi, int ii,
 // The kernel should be launched with the following maximum shapes:
 // grid shape = (nscan, nimage, patch_size)
 // block shape = (min(max_thread, patch_size), 1, 1)
-template < typename patchType, typename imageType >
+template <typename patchType, typename imageType, typename scanType>
 __device__ void
 _loop_over_patches(
-    void operation(patchType *, imageType *, int, int, int, const float[4]),
-    imageType *images,      // has shape (nimage, nimagey, nimagex)
-    patchType *patches,     // has shape (nscan, patch_shape, patch_shape)
-    const float2 *scan,  // has shape (nimage, nscan)
+    void operation(patchType *, imageType *, int, int, int, const scanType[4]),
+    imageType *images,     // has shape (nimage, nimagey, nimagex)
+    patchType *patches,    // has shape (nscan, patch_shape, patch_shape)
+    const scanType *scan,  // has shape (nimage, nscan)
     int nimage, int nimagey, int nimagex,
     int nscan,         // the number of positions per images
     int nrepeat,       // number of times to repeat the patch
@@ -77,18 +77,19 @@ _loop_over_patches(
     // for each scan position
     for (int ts = blockIdx.x; ts < nscan; ts += gridDim.x) {
       // x,y scan coordinates in image
-      const float sx = floor(scan[ts + ti * nscan].y);
-      const float sy = floor(scan[ts + ti * nscan].x);
+      size_t s_index = 2 * (ts + ti * nscan);
+      const scanType sx = floor(scan[s_index + 1]);
+      const scanType sy = floor(scan[s_index]);
 
-      const float sxf = scan[ts + ti * nscan].y - sx;
-      const float syf = scan[ts + ti * nscan].x - sy;
+      const scanType sxf = scan[s_index + 1] - sx;
+      const scanType syf = scan[s_index] - sy;
       assert(1.0f >= sxf && sxf >= 0.0f && 1.0f >= syf && syf >= 0.0f);
 
       // for x,y coords in patch
       for (int py = blockIdx.z; py < patch_shape; py += gridDim.z) {
         if (sy + py < 0 || nimagey <= sy + py) continue;
 
-        const float _syf = ((nimagey > sy + py) ? syf : 0.0f);
+        const scanType _syf = ((nimagey > sy + py) ? syf : 0.0f);
 
         // Only x coodrinate is used in thread block because the max number
         // of threads on an SM is too small for one patch
@@ -102,8 +103,8 @@ _loop_over_patches(
 
           // Linear interpolation. Ternary sets trailing pixel weights to
           // zero when leading pixel is at the edge of the grid.
-          const float _sxf = ((nimagex > sx + px) ? sxf : 0.0f);
-          const float w[4] = {
+          const scanType _sxf = ((nimagex > sx + px) ? sxf : 0.0f);
+          const scanType w[4] = {
               (1.0f - sxf) * (1.0f - syf),
               (sxf) * (1.0f - syf),
               (1.0f - sxf) * (syf),
@@ -121,21 +122,23 @@ _loop_over_patches(
   }
 }
 
-template < typename patchType, typename imageType >
+template <typename patchType, typename imageType, typename scanType>
 __global__ void
-fwd_patch(imageType *images, patchType *patches, const float2 *scan, int nimage,
-          int nimagey, int nimagex, int nscan, int nrepeat, int patch_shape,
-          int padded_shape) {
-  _loop_over_patches<patchType, imageType>(_forward<patchType, imageType>, images, patches, scan, nimage, nimagey, nimagex,
-                     nscan, nrepeat, patch_shape, padded_shape,
-                     nscan * nrepeat);
+fwd_patch(imageType *images, patchType *patches, const scanType *scan,
+          int nimage, int nimagey, int nimagex, int nscan, int nrepeat,
+          int patch_shape, int padded_shape) {
+  _loop_over_patches<patchType, imageType, scanType>(
+      _forward<patchType, imageType, scanType>, images, patches, scan, nimage,
+      nimagey, nimagex, nscan, nrepeat, patch_shape, padded_shape,
+      nscan * nrepeat);
 }
 
-template < typename patchType, typename imageType >
+template <typename patchType, typename imageType, typename scanType>
 __global__ void
-adj_patch(imageType *images, patchType *patches, const float2 *scan, int nimage,
-          int nimagey, int nimagex, int nscan, int nrepeat, int patch_shape,
-          int padded_shape, int npatch) {
-  _loop_over_patches<patchType, imageType>(_adjoint<patchType, imageType>, images, patches, scan, nimage, nimagey, nimagex,
-                     nscan, nrepeat, patch_shape, padded_shape, npatch);
+adj_patch(imageType *images, patchType *patches, const scanType *scan,
+          int nimage, int nimagey, int nimagex, int nscan, int nrepeat,
+          int patch_shape, int padded_shape, int npatch) {
+  _loop_over_patches<patchType, imageType, scanType>(
+      _adjoint<patchType, imageType, scanType>, images, patches, scan, nimage,
+      nimagey, nimagex, nscan, nrepeat, patch_shape, padded_shape, npatch);
 }

--- a/src/tike/operators/cupy/convolution.py
+++ b/src/tike/operators/cupy/convolution.py
@@ -62,10 +62,10 @@ class Convolution(Operator):
         assert psi.shape[:-2] == scan.shape[:-2], (psi.shape, scan.shape)
         assert probe.shape[:-4] == scan.shape[:-2]
         assert probe.shape[-4] == 1 or probe.shape[-4] == scan.shape[-2]
-        patches = self.xp.zeros(
-            (*scan.shape[:-2], scan.shape[-2] * probe.shape[-3],
-             self.detector_shape, self.detector_shape),
-            dtype='complex64',
+        patches = self.xp.zeros_like(
+            psi,
+            shape=(*scan.shape[:-2], scan.shape[-2] * probe.shape[-3],
+                   self.detector_shape, self.detector_shape),
         )
         patches = self.patch.fwd(
             patches=patches,
@@ -88,8 +88,10 @@ class Convolution(Operator):
             nearplane = nearplane.copy()
         nearplane[..., self.pad:self.end, self.pad:self.end] *= probe.conj()
         if psi is None:
-            psi = self.xp.zeros((*scan.shape[:-2], self.nz, self.n),
-                                dtype='complex64')
+            psi = self.xp.zeros_like(
+                nearplane,
+                shape=(*scan.shape[:-2], self.nz, self.n),
+            )
         assert psi.shape[:-2] == scan.shape[:-2]
         return self.patch.adj(
             patches=nearplane.reshape(
@@ -106,10 +108,10 @@ class Convolution(Operator):
         assert nearplane.shape[:-3] == scan.shape[:-1], (nearplane.shape,
                                                          scan.shape)
         assert psi.shape[:-2] == scan.shape[:-2], (psi.shape, scan.shape)
-        patches = self.xp.zeros(
-            (*scan.shape[:-2], scan.shape[-2] * nearplane.shape[-3],
-             self.probe_shape, self.probe_shape),
-            dtype='complex64',
+        patches = self.xp.zeros_like(
+            psi,
+            shape=(*scan.shape[:-2], scan.shape[-2] * nearplane.shape[-3],
+                   self.probe_shape, self.probe_shape),
         )
         patches = self.patch.fwd(
             patches=patches,
@@ -134,10 +136,10 @@ class Convolution(Operator):
 
         patches = self.patch.fwd(
             # Could be xp.empty if scan positions are all in bounds
-            patches=self.xp.zeros(
-                (*scan.shape[:-2], scan.shape[-2] * nearplane.shape[-3],
-                 self.probe_shape, self.probe_shape),
-                dtype='complex64',
+            patches=self.xp.zeros_like(
+                psi,
+                shape=(*scan.shape[:-2], scan.shape[-2] * nearplane.shape[-3],
+                       self.probe_shape, self.probe_shape),
             ),
             images=psi,
             positions=scan,
@@ -167,8 +169,10 @@ class Convolution(Operator):
             )
             probe_amp = self.patch.adj(
                 patches=probe_amp,
-                images=self.xp.zeros((*scan.shape[:-2], self.nz, self.n),
-                                     dtype='complex64'),
+                images=self.xp.zeros_like(
+                    psi,
+                    shape=(*scan.shape[:-2], self.nz, self.n),
+                ),
                 positions=scan,
                 patch_width=self.probe_shape,
                 nrepeat=nearplane.shape[-3],
@@ -178,8 +182,10 @@ class Convolution(Operator):
             patches=nearplane.reshape(
                 (*scan.shape[:-2], scan.shape[-2] * nearplane.shape[-3],
                  *nearplane.shape[-2:])),
-            images=self.xp.zeros((*scan.shape[:-2], self.nz, self.n),
-                                 dtype='complex64'),
+            images=self.xp.zeros_like(
+                psi,
+                shape=(*scan.shape[:-2], self.nz, self.n),
+            ),
             positions=scan,
             patch_width=self.probe_shape,
             nrepeat=nearplane.shape[-3],

--- a/src/tike/operators/cupy/grid.cu
+++ b/src/tike/operators/cupy/grid.cu
@@ -10,21 +10,23 @@
 // Each thread gets one frequency.
 // grid shape (-(-N // max_threads), N, R)
 // block shape (min(N, max_threads), 0, 0)
-extern "C" __global__ void
-make_grids(float* frequency, const float* rotation, int R, int N, float tilt) {
-  float ctilt = cosf(tilt);
-  float stilt = sinf(tilt);
+template <typename frequencyType, typename rotationType>
+__global__ void
+make_grids(frequencyType* frequency, const rotationType* rotation, int R, int N,
+           float tilt) {
+  frequencyType ctilt = cosf(tilt);
+  frequencyType stilt = sinf(tilt);
 
   for (int p = blockIdx.z; p < R; p += gridDim.z) {
-    float ctheta = cosf(rotation[p]);
-    float stheta = sinf(rotation[p]);
+    frequencyType ctheta = cosf(rotation[p]);
+    frequencyType stheta = sinf(rotation[p]);
     // NOTE: Use pointer arithmetic to avoid indexing overflows without using
     // size_t.
-    float* plane = 3 * N * N * p + frequency;
+    frequencyType* plane = 3 * N * N * p + frequency;
 
     for (int y = blockIdx.y; y < N; y += gridDim.y) {
-      float kv = (float)(y - N / 2) / N;
-      float* height = 3 * N * y + plane;
+      frequencyType kv = (frequencyType)(y - N / 2) / N;
+      frequencyType* height = 3 * N * y + plane;
 
       // clang-format off
       for (
@@ -33,8 +35,8 @@ make_grids(float* frequency, const float* rotation, int R, int N, float tilt) {
         x += blockDim.x * gridDim.x
       ) {
         // clang-format on
-        float ku = (float)(x - N / 2) / N;
-        float* f = 3 * x + height;
+        frequencyType ku = (frequencyType)(x - N / 2) / N;
+        frequencyType* f = 3 * x + height;
 
         f[0] = +kv * stilt;
         f[1] = -ku * stheta + kv * ctheta * ctilt;

--- a/src/tike/operators/cupy/patch.py
+++ b/src/tike/operators/cupy/patch.py
@@ -32,7 +32,6 @@ kernels = [
     'adj_patch<double2,float2,double>',
 ]
 
-
 _patch_module = cp.RawModule(
     code=files('tike.operators.cupy').joinpath('convolution.cu').read_text(),
     name_expressions=kernels,
@@ -100,11 +99,11 @@ class Patch(Operator):
                                                             patches.shape)
         assert positions.shape[-2] * nrepeat == patches.shape[-3]
         assert positions.shape[-1] == 2, positions.shape
-        assert positions.dtype == np.single, f"{positions.dtype}"
         nimage = int(np.prod(images.shape[:-2]))
 
         _fwd_patch = _patch_module.get_function(
-            f'fwd_patch<{typename[patches.dtype]},{typename[images.dtype]},{typename[positions.dtype]}>')
+            f'fwd_patch<{typename[patches.dtype]},{typename[images.dtype]},{typename[positions.dtype]}>'
+        )
 
         grids = (
             positions.shape[-2],
@@ -156,13 +155,11 @@ class Patch(Operator):
         K = patches.shape[-3]
         assert (N * nrepeat) % K == 0 and K >= nrepeat
         assert patches.shape[-1] == patches.shape[-2]
-        assert images.dtype == np.csingle, images.dtype
-        assert patches.dtype == np.csingle, patches.dtype
-        assert positions.dtype == np.single, positions.dtype
         nimage = int(np.prod(images.shape[:-2]))
 
         _adj_patch = _patch_module.get_function(
-            f'adj_patch<{typename[patches.dtype]},{typename[images.dtype]},{typename[positions.dtype]}>')
+            f'adj_patch<{typename[patches.dtype]},{typename[images.dtype]},{typename[positions.dtype]}>'
+        )
 
         grids = (
             positions.shape[-2],

--- a/src/tike/operators/cupy/rotate.py
+++ b/src/tike/operators/cupy/rotate.py
@@ -3,6 +3,7 @@ __copyright__ = "Copyright (c) 2020, UChicago Argonne, LLC."
 __docformat__ = 'restructuredtext en'
 
 import numpy as np
+import tike.precision
 
 from .flow import _remap_lanczos
 from .operator import Operator
@@ -27,7 +28,8 @@ class Rotate(Operator):
         shiftj = (unrotated.shape[-1] - 1) / 2.0
 
         i, j = self.xp.mgrid[0:unrotated.shape[-2],
-                             0:unrotated.shape[-1]].astype('float32')
+                             0:unrotated.shape[-1]].astype(
+                                 tike.precision.floating)
 
         i -= shifti
         j -= shiftj

--- a/src/tike/operators/cupy/shift.py
+++ b/src/tike/operators/cupy/shift.py
@@ -29,8 +29,8 @@ class Shift(CachedFFT, Operator):
             overwrite_x=overwrite,
         )
         x, y = self.xp.meshgrid(
-            self.xp.fft.fftfreq(padded.shape[-1]).astype('float32'),
-            self.xp.fft.fftfreq(padded.shape[-2]).astype('float32'),
+            self.xp.fft.fftfreq(padded.shape[-1]).astype(shift.dtype),
+            self.xp.fft.fftfreq(padded.shape[-2]).astype(shift.dtype),
         )
         padded *= self.xp.exp(
             -2j * self.xp.pi *

--- a/src/tike/precision.py
+++ b/src/tike/precision.py
@@ -1,0 +1,5 @@
+import numpy as np
+
+integer = np.intc
+floating = np.single
+cfloating = np.csingle

--- a/src/tike/ptycho/fresnel.py
+++ b/src/tike/ptycho/fresnel.py
@@ -1,5 +1,6 @@
 """Functions for probe initialization using a model of Fresnel optics."""
 import numpy as np
+import tike.precision
 
 
 def single_probe(
@@ -60,7 +61,8 @@ def single_probe(
 
     probe = probe / (np.sqrt(np.sum(np.abs(probe)**2)))
 
-    return probe[np.newaxis, np.newaxis, np.newaxis].astype(np.complex64)
+    return probe[np.newaxis, np.newaxis,
+                 np.newaxis].astype(tike.precision.cfloating)
 
 
 def MW_probe(
@@ -153,7 +155,7 @@ def MW_probe(
         probe.append(nprobe * (np.sqrt(spectrum[i, 1])))
 
     probe = np.stack(probe, axis=0)
-    return probe[np.newaxis, np.newaxis].astype('complex64')
+    return probe[np.newaxis, np.newaxis].astype(tike.precision.cfloating)
 
 
 def _gaussian_spectrum(lambda0, bandwidth, energy):

--- a/src/tike/ptycho/learn.py
+++ b/src/tike/ptycho/learn.py
@@ -28,8 +28,8 @@ def extract_patches(psi, scan, patch_width):
     """
     check_allowed_positions(scan, psi, (patch_width, patch_width))
     with Patch() as operator:
-        psi = operator.asarray(psi, dtype='complex64')
-        scan = operator.asarray(scan, dtype='float32')
+        psi = operator.asarray(psi)
+        scan = operator.asarray(scan)
         patches = operator.fwd(
             images=psi,
             positions=scan,

--- a/src/tike/ptycho/object.py
+++ b/src/tike/ptycho/object.py
@@ -14,6 +14,7 @@ import numpy as np
 import scipy.interpolate
 
 import tike.linalg
+import tike.precision
 
 logger = logging.getLogger(__name__)
 
@@ -126,7 +127,8 @@ def smoothness_constraint(x, a):
     """
     if 0 <= a and a < 1.0 / 8.0:
         logger.info("Object smooth constrained with kernel param %.3e", a)
-        weights = cp.ones([1] * (x.ndim - 2) + [3, 3], dtype='float32') * a
+        weights = cp.ones([1] * (x.ndim - 2) + [3, 3],
+                          dtype=tike.precision.floating) * a
         weights[..., 1, 1] = 1.0 - 8.0 * a
         x.real = cupyx.scipy.ndimage.convolve(x.real, weights, mode='nearest')
         x.imag = cupyx.scipy.ndimage.convolve(x.imag, weights, mode='nearest')
@@ -136,7 +138,7 @@ def smoothness_constraint(x, a):
             f"Smoothness constraint must be in range [0, 1/8) not {a}.")
 
 
-def get_padded_object(scan, probe, extra:int=0):
+def get_padded_object(scan, probe, extra: int = 0):
     """Return a ones-initialized object and shifted scan positions.
 
     An complex object array is initialized with shape such that the area
@@ -148,10 +150,10 @@ def get_padded_object(scan, probe, extra:int=0):
     min_corner = np.min(int_scan, axis=-2)
     max_corner = np.max(int_scan, axis=-2)
     span = max_corner - min_corner + probe.shape[-1] + 2 + 2 * extra
-    return np.full(
-        shape=span.astype('int'),
-        dtype='complex64',
-        fill_value=np.complex64(0.5 + 0j),
+    return np.full_like(
+        probe,
+        shape=span.astype(tike.precision.integer),
+        fill_value=tike.precision.cfloating(0.5 + 0j),
     ), scan + 1 - min_corner + extra
 
 

--- a/src/tike/ptycho/solvers/conjugate.py
+++ b/src/tike/ptycho/solvers/conjugate.py
@@ -202,7 +202,6 @@ def _update_object(
         grad_list = comm.pool.map(op.grad_psi, data, psi, scan, probe)
         return comm.Allreduce_reduce_gpu(grad_list)
 
-
     def dir_multi(dir):
         """Scatter dir to all GPUs"""
         return comm.pool.bcast(dir)

--- a/src/tike/ptycho/solvers/dm.py
+++ b/src/tike/ptycho/solvers/dm.py
@@ -308,10 +308,7 @@ def _apply_update(
 
 def _get_patches(nearplane, psi, scan, op=None):
     patches = op.diffraction.patch.fwd(
-        patches=cp.zeros(
-            nearplane[..., 0, 0, :, :].shape,
-            dtype='complex64',
-        ),
+        patches=cp.zeros_like(nearplane[..., 0, 0, :, :]),
         images=psi,
         positions=scan,
     )[..., None, None, :, :]
@@ -329,11 +326,9 @@ def _get_nearplane_gradients(
     recover_positions=True,
     op=None,
 ):
-    psi_update_numerator = cp.zeros(psi.shape, dtype='complex64')
-    psi_update_denominator = cp.zeros(psi.shape, dtype='complex64')
-    probe_update_numerator = cp.zeros(probe.shape, dtype='complex64')
-    # position_update_numerator = cp.zeros(scan.shape, dtype='float32')
-    # position_update_denominator = cp.zeros(scan.shape, dtype='float32')
+    psi_update_numerator = cp.zeros_like(psi)
+    psi_update_denominator = cp.zeros_like(psi)
+    probe_update_numerator = cp.zeros_like(probe)
 
     for m in range(probe.shape[-3]):
 
@@ -374,6 +369,4 @@ def _get_nearplane_gradients(
         psi_update_denominator,
         probe_update_numerator,
         probe_update_denominator,
-        # position_update_numerator,
-        # position_update_denominator,
     )

--- a/src/tike/ptycho/solvers/rpie.py
+++ b/src/tike/ptycho/solvers/rpie.py
@@ -7,6 +7,7 @@ import tike.opt
 import tike.ptycho.position
 import tike.ptycho.probe
 import tike.operators.cupy.objective as objective
+import tike.precision
 
 from ..object import positivity_constraint, smoothness_constraint
 
@@ -280,7 +281,8 @@ def _update_nearplane(
         )
 
         b1 = probe_options.additional_probe_penalty * cp.linspace(
-            0, 1, probe[0].shape[-3], dtype='float32')[..., None, None]
+            0, 1, probe[0].shape[-3], dtype=tike.precision.floating)[..., None,
+                                                                     None]
 
         probe[0] += step_length * (probe_update_numerator -
                                    (b1 + b0) * probe[0]) / (
@@ -311,10 +313,7 @@ def _update_nearplane(
 
 def _get_patches(nearplane, psi, scan, op=None):
     patches = op.diffraction.patch.fwd(
-        patches=cp.zeros(
-            nearplane[..., 0, 0, :, :].shape,
-            dtype='complex64',
-        ),
+        patches=cp.zeros_like(nearplane[..., 0, 0, :, :]),
         images=psi,
         positions=scan,
     )[..., None, None, :, :]
@@ -332,11 +331,11 @@ def _get_nearplane_gradients(
     recover_positions=True,
     op=None,
 ):
-    psi_update_numerator = cp.zeros(psi.shape, dtype='complex64')
-    psi_update_denominator = cp.zeros(psi.shape, dtype='complex64')
-    probe_update_numerator = cp.zeros(probe.shape, dtype='complex64')
-    position_update_numerator = cp.zeros(scan.shape, dtype='float32')
-    position_update_denominator = cp.zeros(scan.shape, dtype='float32')
+    psi_update_numerator = cp.zeros_like(psi)
+    psi_update_denominator = cp.zeros_like(psi)
+    probe_update_numerator = cp.zeros_like(probe)
+    position_update_numerator = cp.zeros_like(scan)
+    position_update_denominator = cp.zeros_like(scan)
 
     grad_x, grad_y = tike.ptycho.position.gaussian_gradient(patches)
 

--- a/src/tike/random.py
+++ b/src/tike/random.py
@@ -5,17 +5,26 @@ import logging
 import cupy as cp
 import numpy as np
 
+import tike.precision
+
+randomizer_np = np.random.default_rng()
+randomizer_cp = cp.random.default_rng()
+
 logger = logging.getLogger(__name__)
 
 
 def numpy_complex(*shape):
     """Return a complex random array in the range [-0.5, 0.5)."""
-    return (np.random.rand(*shape, 2) - 0.5).view('complex')[..., 0]
+    return (
+        randomizer_np.random(size=(*shape, 2), dtype=tike.precision.floating) -
+        0.5).view(tike.precision.cfloating)[..., 0]
 
 
 def cupy_complex(*shape):
     """Return a complex random array in the range [-0.5, 0.5)."""
-    return (cp.random.rand(*shape, 2) - 0.5).view('complex')[..., 0]
+    return (
+        randomizer_cp.random(size=(*shape, 2), dtype=tike.precision.floating) -
+        0.5).view(tike.precision.cfloating)[..., 0]
 
 
 def cluster_wobbly_center(*args, **kwargs):

--- a/tests/operators/test_alignment.py
+++ b/tests/operators/test_alignment.py
@@ -5,6 +5,7 @@ import unittest
 
 import numpy as np
 from tike.operators import Alignment
+import tike.precision
 
 from .util import random_complex, OperatorTests
 
@@ -24,22 +25,22 @@ class TestAlignment(unittest.TestCase, OperatorTests):
         self.xp = self.operator.xp
 
         padded_shape = shape + np.asarray((0, 41, 32))
-        flow = (self.xp.random.rand(*padded_shape, 2, dtype='float32') -
-                0.5) * 9
-        shift = self.xp.random.rand(*shape[:-2], 2) - 0.5
+        flow = (self.xp.random.rand(
+            *padded_shape, 2, dtype=tike.precision.floating) - 0.5) * 9
+        shift = self.xp.random.rand(
+            *shape[:-2], 2, dtype=tike.precision.floating) - 0.5
 
         np.random.seed(0)
-        self.m = self.xp.asarray(random_complex(*shape), dtype='complex64')
+        self.m = self.xp.asarray(random_complex(*shape))
         self.m_name = 'unpadded'
-        self.d = self.xp.asarray(random_complex(*padded_shape),
-                                 dtype='complex64')
+        self.d = self.xp.asarray(random_complex(*padded_shape))
         self.d_name = 'rotated'
         self.kwargs = {
             'flow': flow,
             'shift': shift,
             'padded_shape': padded_shape,
             'unpadded_shape': shape,
-            'angle': np.random.rand() * 2 * np.pi,
+            'angle': tike.precision.floating(np.random.rand() * 2 * np.pi),
             'cval': 0,
         }
         print(self.operator)

--- a/tests/operators/test_checkerboard.py
+++ b/tests/operators/test_checkerboard.py
@@ -1,5 +1,6 @@
 """Check whether the checkerboard algorithm is equivalent to fftshift."""
 import numpy as xp
+import tike.precision
 
 from tike.operators.cupy.usfft import checkerboard
 
@@ -25,7 +26,7 @@ def shifted_fft_ref(a, xp):
 def test_checkerboard_correctness():
     shape = xp.random.randint(1, 32, 3) * 2
     a = xp.random.rand(*shape) + 1j * xp.random.rand(*shape)
-    a = a.astype('complex64')
+    a = a.astype(tike.precision.cfloating)
     b = a.copy()
     a = shifted_fft_ref(a, xp)
     b = shifted_fft_two(b, xp)

--- a/tests/operators/test_convolution.py
+++ b/tests/operators/test_convolution.py
@@ -6,8 +6,11 @@ import unittest
 
 import numpy as np
 from tike.operators import Convolution
+import tike.precision
+import tike.linalg
+import tike.random
 
-from .util import random_complex, inner_complex, OperatorTests
+from .util import OperatorTests
 
 __author__ = "Daniel Ching"
 __copyright__ = "Copyright (c) 2020, UChicago Argonne, LLC."
@@ -40,30 +43,31 @@ class TestConvolution(unittest.TestCase, OperatorTests):
 
         np.random.seed(0)
         scan = np.random.rand(self.ntheta, self.nscan, 2) * (127 - 15 - 1)
-        original = random_complex(*self.original_shape)
-        nearplane = random_complex(self.ntheta, self.nscan, self.nprobe,
-                                   self.detector_shape, self.detector_shape)
-        kernel = random_complex(self.ntheta, self.nscan, self.nprobe,
-                                self.probe_shape, self.probe_shape)
+        original = tike.random.numpy_complex(*self.original_shape)
+        nearplane = tike.random.numpy_complex(self.ntheta, self.nscan,
+                                              self.nprobe, self.detector_shape,
+                                              self.detector_shape)
+        kernel = tike.random.numpy_complex(self.ntheta, self.nscan, self.nprobe,
+                                           self.probe_shape, self.probe_shape)
 
-        self.m = self.xp.asarray(original, dtype='complex64')
+        self.m = self.xp.asarray(original)
         self.m_name = 'psi'
         self.kwargs = {
-            'scan': self.xp.asarray(scan, dtype='float32'),
-            'probe': self.xp.asarray(kernel, dtype='complex64')
+            'scan': self.xp.asarray(scan, dtype=tike.precision.floating),
+            'probe': self.xp.asarray(kernel)
         }
 
-        self.m1 = self.xp.asarray(kernel, dtype='complex64')
+        self.m1 = self.xp.asarray(kernel)
         self.m1_name = 'probe'
         self.kwargs1 = {
-            'scan': self.xp.asarray(scan, dtype='float32'),
-            'psi': self.xp.asarray(original, dtype='complex64')
+            'scan': self.xp.asarray(scan, dtype=tike.precision.floating),
+            'psi': self.xp.asarray(original)
         }
         self.kwargs2 = {
-            'scan': self.xp.asarray(scan, dtype='float32'),
+            'scan': self.xp.asarray(scan, dtype=tike.precision.floating),
         }
 
-        self.d = self.xp.asarray(nearplane, dtype='complex64')
+        self.d = self.xp.asarray(nearplane)
         self.d_name = 'nearplane'
 
         print(self.operator)
@@ -74,8 +78,8 @@ class TestConvolution(unittest.TestCase, OperatorTests):
         assert d.shape == self.d.shape
         m = self.operator.adj_probe(**{self.d_name: self.d}, **self.kwargs1)
         assert m.shape == self.m1.shape
-        a = inner_complex(d, self.d)
-        b = inner_complex(self.m1, m)
+        a = tike.linalg.inner(d, self.d)
+        b = tike.linalg.inner(self.m1, m)
         print()
         print('<Fm,   m> = {:.6f}{:+.6f}j'.format(a.real.item(), a.imag.item()))
         print('< d, F*d> = {:.6f}{:+.6f}j'.format(b.real.item(), b.imag.item()))
@@ -113,9 +117,9 @@ class TestConvolution(unittest.TestCase, OperatorTests):
         )
         assert m.shape == self.m.shape
         assert m1.shape == self.m1.shape
-        a = inner_complex(d, self.d)
-        b = inner_complex(self.m, m)
-        c = inner_complex(self.m1, m1)
+        a = tike.linalg.inner(d, self.d)
+        b = tike.linalg.inner(self.m, m)
+        c = tike.linalg.inner(self.m1, m1)
         print()
         print('< Fm,    m> = {:.6f}{:+.6f}j'.format(a.real.item(),
                                                     a.imag.item()))

--- a/tests/operators/test_convolution.py
+++ b/tests/operators/test_convolution.py
@@ -83,8 +83,8 @@ class TestConvolution(unittest.TestCase, OperatorTests):
         print()
         print('<Fm,   m> = {:.6f}{:+.6f}j'.format(a.real.item(), a.imag.item()))
         print('< d, F*d> = {:.6f}{:+.6f}j'.format(b.real.item(), b.imag.item()))
-        self.xp.testing.assert_allclose(a.real, b.real, rtol=1e-5, atol=0)
-        self.xp.testing.assert_allclose(a.imag, b.imag, rtol=1e-5, atol=0)
+        self.xp.testing.assert_allclose(a.real, b.real, rtol=1e-4, atol=0)
+        self.xp.testing.assert_allclose(a.imag, b.imag, rtol=1e-4, atol=0)
 
     def test_adj_probe_time(self):
         """Time the adjoint operation."""
@@ -127,10 +127,10 @@ class TestConvolution(unittest.TestCase, OperatorTests):
                                                     b.imag.item()))
         print('< d1, F*d1> = {:.6f}{:+.6f}j'.format(c.real.item(),
                                                     c.imag.item()))
-        self.xp.testing.assert_allclose(a.real, b.real, rtol=1e-5, atol=0)
-        self.xp.testing.assert_allclose(a.imag, b.imag, rtol=1e-5, atol=0)
-        self.xp.testing.assert_allclose(a.real, c.real, rtol=1e-5, atol=0)
-        self.xp.testing.assert_allclose(a.imag, c.imag, rtol=1e-5, atol=0)
+        self.xp.testing.assert_allclose(a.real, b.real, rtol=1e-4, atol=0)
+        self.xp.testing.assert_allclose(a.imag, b.imag, rtol=1e-4, atol=0)
+        self.xp.testing.assert_allclose(a.real, c.real, rtol=1e-4, atol=0)
+        self.xp.testing.assert_allclose(a.imag, c.imag, rtol=1e-4, atol=0)
 
 
 if __name__ == '__main__':

--- a/tests/operators/test_flow.py
+++ b/tests/operators/test_flow.py
@@ -6,7 +6,7 @@ import unittest
 import numpy as np
 from tike.operators import Flow
 
-from .util import random_complex, OperatorTests
+from .util import random_complex, random_floating, OperatorTests
 
 __author__ = "Daniel Ching, Viktor Nikitin"
 __copyright__ = "Copyright (c) 2020, UChicago Argonne, LLC."
@@ -24,16 +24,12 @@ class TestFlow(unittest.TestCase, OperatorTests):
         self.xp = self.operator.xp
 
         np.random.seed(0)
-        self.m = self.xp.asarray(random_complex(ntheta, nz, n),
-                                 dtype='complex64')
+        self.m = self.xp.asarray(random_complex(ntheta, nz, n))
         self.m_name = 'f'
-        self.d = self.xp.asarray(random_complex(*self.m.shape),
-                                 dtype='complex64')
+        self.d = self.xp.asarray(random_complex(*self.m.shape))
         self.d_name = 'g'
         self.kwargs = {
-            'flow':
-                self.xp.asarray((np.random.rand(*self.m.shape, 2) - 0.5) * 16,
-                                dtype='float32'),
+            'flow': self.xp.asarray(random_floating(*self.m.shape, 2) * 16),
         }
         print(self.operator)
 

--- a/tests/operators/test_lamino.py
+++ b/tests/operators/test_lamino.py
@@ -5,6 +5,7 @@ import unittest
 
 import numpy as np
 from tike.operators import Lamino, Bucket
+import tike.precision
 
 from .util import random_complex, OperatorTests
 
@@ -25,13 +26,14 @@ class TestLaminoFourier(unittest.TestCase, OperatorTests):
         self.operator.__enter__()
         self.xp = self.operator.xp
         np.random.seed(0)
-        self.m = self.xp.asarray(random_complex(n, n, n), dtype='complex64')
+        self.m = self.xp.asarray(random_complex(n, n, n))
         self.m_name = 'u'
-        self.d = self.xp.asarray(random_complex(ntheta, n, n),
-                                 dtype='complex64')
+        self.d = self.xp.asarray(random_complex(ntheta, n, n))
         self.d_name = 'data'
         self.kwargs = {
-            'theta': self.xp.linspace(0, 2 * np.pi, ntheta).astype('float32')
+            'theta':
+                self.xp.linspace(0, 2 * np.pi,
+                                 ntheta).astype(tike.precision.floating)
         }
         print(self.operator)
 
@@ -52,14 +54,16 @@ class TestLaminoBucket(unittest.TestCase, OperatorTests):
         self.operator.__enter__()
         self.xp = self.operator.xp
         np.random.seed(0)
-        self.m = self.xp.asarray(random_complex(n, n, n), dtype='complex64')
+        self.m = self.xp.asarray(random_complex(n, n, n),
+                                 dtype=tike.precision.cfloating)
         self.m_name = 'u'
         self.d = self.xp.asarray(random_complex(ntheta, n, n),
-                                 dtype='complex64')
+                                 dtype=tike.precision.cfloating)
         self.d_name = 'data'
         self.kwargs = {
             'theta':
-                self.xp.linspace(0, 2 * np.pi, ntheta).astype('float32'),
+                self.xp.linspace(0, 2 * np.pi,
+                                 ntheta).astype(tike.precision.floating),
             'grid':
                 self.xp.asarray(self.operator._make_grid().reshape(n**3, 3),
                                 dtype='int16'),

--- a/tests/operators/test_pad.py
+++ b/tests/operators/test_pad.py
@@ -27,10 +27,9 @@ class TestPad(unittest.TestCase, OperatorTests):
         corner = self.xp.asarray(np.random.randint(0, 32, size=(shape[0], 2)))
 
         np.random.seed(0)
-        self.m = self.xp.asarray(random_complex(*shape), dtype='complex64')
+        self.m = self.xp.asarray(random_complex(*shape))
         self.m_name = 'unpadded'
-        self.d = self.xp.asarray(random_complex(*padded_shape),
-                                 dtype='complex64')
+        self.d = self.xp.asarray(random_complex(*padded_shape))
         self.d_name = 'padded'
         self.kwargs = {
             'corner': corner,
@@ -53,10 +52,9 @@ class TestPadDefaults(unittest.TestCase, OperatorTests):
         padded_shape = shape
 
         np.random.seed(0)
-        self.m = self.xp.asarray(random_complex(*shape), dtype='complex64')
+        self.m = self.xp.asarray(random_complex(*shape))
         self.m_name = 'unpadded'
-        self.d = self.xp.asarray(random_complex(*padded_shape),
-                                 dtype='complex64')
+        self.d = self.xp.asarray(random_complex(*padded_shape))
         self.d_name = 'padded'
         self.kwargs = {
             'corner': None,

--- a/tests/operators/test_patch.py
+++ b/tests/operators/test_patch.py
@@ -6,8 +6,10 @@ import unittest
 import cupy as cp
 import numpy as np
 from tike.operators import Patch
+import tike.precision
+import tike.linalg
 
-from .util import random_complex, inner_complex, OperatorTests
+from .util import random_complex, OperatorTests
 
 __author__ = "Daniel Ching"
 __copyright__ = "Copyright (c) 2020, UChicago Argonne, LLC."
@@ -20,10 +22,10 @@ class TestPatch(unittest.TestCase, OperatorTests):
     def setUp(self):
         """Load a dataset for reconstruction."""
 
-        self.ntheta = 10
-        self.nscan = 73
+        self.ntheta = 3
+        self.nscan = 7
         self.original_shape = (self.ntheta, 256, 256)
-        self.probe_shape = 15
+        self.probe_shape = 16
         self.detector_shape = self.probe_shape
 
         self.operator = Patch()
@@ -40,16 +42,16 @@ class TestPatch(unittest.TestCase, OperatorTests):
         # original /= np.linalg.norm(original)
         # nearplane /= np.linalg.norm(nearplane)
 
-        self.m = self.xp.asarray(original, dtype='complex64')
+        self.m = self.xp.asarray(original)
         self.m_name = 'images'
         self.kwargs = {
-            'positions': self.xp.asarray(scan, dtype='float32'),
+            'positions': self.xp.asarray(scan, dtype=tike.precision.floating),
             'patch_width': self.probe_shape,
             'height': self.original_shape[-2],
             'width': self.original_shape[-1],
         }
 
-        self.d = self.xp.asarray(nearplane, dtype='complex64')
+        self.d = self.xp.asarray(nearplane)
         self.d_name = 'patches'
 
         print(self.operator)
@@ -63,20 +65,27 @@ def test_patch_correctness(size=256, win=8):
 
     try:
         import libimage
+        import tike.precision
         fov = (libimage.load('coins', size) +
-               1j * libimage.load('earring', size)).astype('complex64')
+               1j * libimage.load('earring', size))
     except ModuleNotFoundError:
         import tike.random
-        fov = tike.random.numpy_complex(size, size)
+        fov = tike.random.numpy_complex(
+            size,
+            size,
+        )
+    fov = fov.astype(tike.precision.cfloating)
 
+    subpixel = 0.12346789
     positions = np.array([
         [0, 0],
         [0, size - win],
         [size - win, 0],
         [size - win, size - win],
         [size // 2 - win // 2, size // 2 - win // 2],
-        [0.123, 3],
-    ])
+        [subpixel, 3],
+    ],
+                         dtype=tike.precision.floating)
     truth = np.stack(
         (
             fov[:win, :win],
@@ -85,15 +94,15 @@ def test_patch_correctness(size=256, win=8):
             fov[-win:, -win:],
             fov[size // 2 - win // 2:size // 2 - win // 2 + win,
                 size // 2 - win // 2:size // 2 - win // 2 + win],
-            (1 - 0.123) * fov[0:win, 3:3 + win] +
-            0.123 * fov[1:1 + win, 3:3 + win],
+            (1.0 - subpixel) * fov[0:win, 3:3 + win] +
+            subpixel * fov[1:1 + win, 3:3 + win],
         ),
         axis=0,
     )
     with Patch() as op:
         patches = op.fwd(
-            images=cp.array(fov, dtype='complex64', order='C'),
-            positions=cp.array(positions, dtype='float32', order='C'),
+            images=cp.array(fov),
+            positions=cp.array(positions),
             patch_width=win,
         ).get()
 
@@ -136,7 +145,7 @@ def test_patch_correctness_adjoint(size=8, win=2):
         [3, 0.123],
         [5.5, 3.5],
     ])
-    fov = cp.zeros((size, size), dtype='complex64')
+    fov = cp.zeros((size, size), dtype=tike.precision.cfloating)
     fov[:win, :win] += 1
     fov[:win, -win:] += 1
     fov[-win:, :win] += 1
@@ -145,21 +154,29 @@ def test_patch_correctness_adjoint(size=8, win=2):
         size // 2 - win // 2:size // 2 - win // 2 + win] += 1
     fov[0:win, 3:3 + win] += (1 - 0.123)
     fov[1:1 + win, 3:3 + win] += 0.123
-    fov[3:3 + win, 0:win, ] += (1 - 0.123)
-    fov[3:3 + win, 1:1 + win, ] += 0.123
-    fov[5:5+win, 3:3+win] += 0.25
-    fov[6:6+win, 3:3+win] += 0.25
-    fov[5:5+win, 4:4+win] += 0.25
-    fov[6:6+win, 4:4+win] += 0.25
+    fov[3:3 + win, 0:win,] += (1 - 0.123)
+    fov[3:3 + win, 1:1 + win,] += 0.123
+    fov[5:5 + win, 3:3 + win] += 0.25
+    fov[6:6 + win, 3:3 + win] += 0.25
+    fov[5:5 + win, 4:4 + win] += 0.25
+    fov[6:6 + win, 4:4 + win] += 0.25
 
-    patches = cp.ones((len(positions), win, win), dtype='complex64')
+    patches = cp.ones((len(positions), win, win),
+                      dtype=tike.precision.cfloating)
     with Patch() as op:
-        combined = op.adj(patches=patches,
-                          positions=cp.array(positions,
-                                             dtype='float32',
-                                             order='C'),
-                          patch_width=win,
-                          images=cp.zeros((size, size), dtype='complex64'))
+        combined = op.adj(
+            patches=patches,
+            positions=cp.array(
+                positions,
+                dtype=tike.precision.floating,
+                order='C',
+            ),
+            patch_width=win,
+            images=cp.zeros(
+                (size, size),
+                dtype=tike.precision.cfloating,
+            ),
+        )
 
     fov = fov.get()
     combined = combined.get()
@@ -170,10 +187,13 @@ def test_patch_correctness_adjoint(size=8, win=2):
         plt.figure()
         plt.subplot(1, 3, 1)
         plt.imshow(fov.real)
+        plt.title('true')
         plt.subplot(1, 3, 2)
         plt.imshow(combined.real)
+        plt.title('patch operator')
         plt.subplot(1, 3, 3)
         plt.imshow(combined.real - fov.real, cmap=plt.cm.inferno)
+        plt.title('error')
         plt.colorbar()
         plt.savefig('patches-adj.png')
     except ModuleNotFoundError:

--- a/tests/operators/test_propagation.py
+++ b/tests/operators/test_propagation.py
@@ -5,6 +5,7 @@ import unittest
 
 import numpy as np
 from tike.operators import Propagation
+import tike.precision
 
 from .util import random_complex, OperatorTests
 
@@ -26,13 +27,11 @@ class TestPropagation(unittest.TestCase, OperatorTests):
         self.operator.__enter__()
         self.xp = self.operator.xp
         np.random.seed(0)
-        self.m = self.xp.asarray(random_complex(nwaves, probe_shape,
-                                                probe_shape),
-                                 dtype='complex64')
+        self.m = self.xp.asarray(
+            random_complex(nwaves, probe_shape, probe_shape))
         self.m_name = 'nearplane'
-        self.d = self.xp.asarray(random_complex(nwaves, probe_shape,
-                                                probe_shape),
-                                 dtype='complex64')
+        self.d = self.xp.asarray(
+            random_complex(nwaves, probe_shape, probe_shape))
         self.d_name = 'farplane'
         self.kwargs = {}
         print(self.operator)

--- a/tests/operators/test_ptycho.py
+++ b/tests/operators/test_ptycho.py
@@ -6,8 +6,10 @@ import unittest
 
 import numpy as np
 from tike.operators import Ptycho
+import tike.precision
+import tike.linalg
 
-from .util import random_complex, inner_complex, OperatorTests
+from .util import random_complex, OperatorTests
 
 __author__ = "Daniel Ching"
 __copyright__ = "Copyright (c) 2020, UChicago Argonne, LLC."
@@ -29,7 +31,8 @@ class TestPtycho(unittest.TestCase, OperatorTests):
         print(Ptycho)
 
         np.random.seed(0)
-        scan = np.random.rand(*self.scan_shape).astype('float32') * (127 - 16)
+        scan = np.random.rand(*self.scan_shape).astype(
+            tike.precision.floating) * (127 - 16)
         probe = random_complex(*self.probe_shape)
         original = random_complex(*self.original_shape)
         farplane = random_complex(*self.probe_shape[:-2], *self.detector_shape)
@@ -45,29 +48,24 @@ class TestPtycho(unittest.TestCase, OperatorTests):
         self.operator.__enter__()
         self.xp = self.operator.xp
 
-        probe = self.xp.asarray(probe.astype('complex64'))
-        original = self.xp.asarray(original.astype('complex64'))
-        farplane = self.xp.asarray(farplane.astype('complex64'))
-        scan = self.xp.asarray(scan.astype('float32'))
-
-        self.m = self.xp.asarray(original, dtype='complex64')
+        self.m = self.xp.asarray(original)
         self.m_name = 'psi'
         self.kwargs = {
-            'scan': self.xp.asarray(scan, dtype='float32'),
-            'probe': self.xp.asarray(probe, dtype='complex64')
+            'scan': self.xp.asarray(scan),
+            'probe': self.xp.asarray(probe)
         }
 
-        self.m1 = self.xp.asarray(probe, dtype='complex64')
+        self.m1 = self.xp.asarray(probe)
         self.m1_name = 'probe'
         self.kwargs1 = {
-            'scan': self.xp.asarray(scan, dtype='float32'),
-            'psi': self.xp.asarray(original, dtype='complex64')
+            'scan': self.xp.asarray(scan),
+            'psi': self.xp.asarray(original)
         }
         self.kwargs2 = {
-            'scan': self.xp.asarray(scan, dtype='float32'),
+            'scan': self.xp.asarray(scan),
         }
 
-        self.d = self.xp.asarray(farplane, dtype='complex64')
+        self.d = self.xp.asarray(farplane)
         self.d_name = 'farplane'
 
     def test_adjoint_probe(self):
@@ -76,8 +74,8 @@ class TestPtycho(unittest.TestCase, OperatorTests):
         assert d.shape == self.d.shape
         m = self.operator.adj_probe(**{self.d_name: self.d}, **self.kwargs1)
         assert m.shape == self.m1.shape
-        a = inner_complex(d, self.d)
-        b = inner_complex(self.m1, m)
+        a = tike.linalg.inner(d, self.d)
+        b = tike.linalg.inner(self.m1, m)
         print()
         print('<Fm,   m> = {:.5g}{:+.5g}j'.format(a.real.item(), a.imag.item()))
         print('< d, F*d> = {:.5g}{:+.5g}j'.format(b.real.item(), b.imag.item()))
@@ -115,9 +113,9 @@ class TestPtycho(unittest.TestCase, OperatorTests):
         )
         assert m.shape == self.m.shape
         assert m1.shape == self.m1.shape
-        a = inner_complex(d, self.d)
-        b = inner_complex(self.m, m)
-        c = inner_complex(self.m1, m1)
+        a = tike.linalg.inner(d, self.d)
+        b = tike.linalg.inner(self.m, m)
+        c = tike.linalg.inner(self.m1, m1)
         print()
         print('< Fm,    m> = {:.5g}{:+.5g}j'.format(a.real.item(),
                                                     a.imag.item()))

--- a/tests/operators/test_ptycho.py
+++ b/tests/operators/test_ptycho.py
@@ -79,8 +79,8 @@ class TestPtycho(unittest.TestCase, OperatorTests):
         print()
         print('<Fm,   m> = {:.5g}{:+.5g}j'.format(a.real.item(), a.imag.item()))
         print('< d, F*d> = {:.5g}{:+.5g}j'.format(b.real.item(), b.imag.item()))
-        self.xp.testing.assert_allclose(a.real, b.real, rtol=1e-5, atol=0)
-        self.xp.testing.assert_allclose(a.imag, b.imag, rtol=1e-5, atol=0)
+        self.xp.testing.assert_allclose(a.real, b.real, rtol=1e-4, atol=0)
+        self.xp.testing.assert_allclose(a.imag, b.imag, rtol=1e-4, atol=0)
 
     def test_adj_probe_time(self):
         """Time the adjoint operation."""
@@ -123,10 +123,10 @@ class TestPtycho(unittest.TestCase, OperatorTests):
                                                     b.imag.item()))
         print('< d1, F*d1> = {:.5g}{:+.5g}j'.format(c.real.item(),
                                                     c.imag.item()))
-        self.xp.testing.assert_allclose(a.real, b.real, rtol=1e-5, atol=0)
-        self.xp.testing.assert_allclose(a.imag, b.imag, rtol=1e-5, atol=0)
-        self.xp.testing.assert_allclose(a.real, c.real, rtol=1e-5, atol=0)
-        self.xp.testing.assert_allclose(a.imag, c.imag, rtol=1e-5, atol=0)
+        self.xp.testing.assert_allclose(a.real, b.real, rtol=1e-4, atol=0)
+        self.xp.testing.assert_allclose(a.imag, b.imag, rtol=1e-4, atol=0)
+        self.xp.testing.assert_allclose(a.real, c.real, rtol=1e-4, atol=0)
+        self.xp.testing.assert_allclose(a.imag, c.imag, rtol=1e-4, atol=0)
 
 
 if __name__ == '__main__':

--- a/tests/operators/test_rotate.py
+++ b/tests/operators/test_rotate.py
@@ -5,6 +5,7 @@ import unittest
 
 import numpy as np
 from tike.operators import Rotate
+import tike.precision
 
 from .util import random_complex, OperatorTests
 
@@ -24,9 +25,9 @@ class TestRotate(unittest.TestCase, OperatorTests):
         self.xp = self.operator.xp
 
         np.random.seed(0)
-        self.m = self.xp.asarray(random_complex(*shape), dtype='complex64')
+        self.m = self.xp.asarray(random_complex(*shape))
         self.m_name = 'unrotated'
-        self.d = self.xp.asarray(random_complex(*shape), dtype='complex64')
+        self.d = self.xp.asarray(random_complex(*shape))
         self.d_name = 'rotated'
         self.kwargs = {
             'angle': np.random.rand() * 2 * np.pi,
@@ -38,7 +39,8 @@ class TestRotate(unittest.TestCase, OperatorTests):
         import matplotlib
         matplotlib.use('Agg')
         from matplotlib import pyplot as plt
-        x = self.xp.asarray(libimage.load('coins', 256), dtype='complex64')
+        x = self.xp.asarray(libimage.load('coins', 256),
+                            dtype=tike.precision.cfloating)
         y = self.operator.fwd(x[None], 4 * np.pi)
 
         print(x.shape, y.shape)

--- a/tests/operators/test_shift.py
+++ b/tests/operators/test_shift.py
@@ -5,6 +5,7 @@ import unittest
 
 import numpy as np
 from tike.operators import Shift
+import tike.precision
 
 from .util import random_complex, OperatorTests
 
@@ -21,16 +22,14 @@ class TestShift(unittest.TestCase, OperatorTests):
         self.operator.__enter__()
         self.xp = self.operator.xp
         np.random.seed(0)
-        self.m = self.xp.asarray(random_complex(ntheta, nz, n),
-                                 dtype='complex64')
+        self.m = self.xp.asarray(random_complex(ntheta, nz, n))
         self.m_name = 'a'
-        self.d = self.xp.asarray(random_complex(*self.m.shape),
-                                 dtype='complex64')
+        self.d = self.xp.asarray(random_complex(*self.m.shape))
         self.d_name = 'a'
         self.kwargs = {
             'shift':
                 self.xp.asarray((np.random.random([ntheta, 2]) - 0.5) * 7,
-                                dtype='float32')
+                                dtype=tike.precision.floating)
         }
         print(self.operator)
 

--- a/tests/operators/test_sum.py
+++ b/tests/operators/test_sum.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import unittest
+
+import numpy as np
+from tike.operators import Operator
+
+from .util import random_complex, OperatorTests
+
+__author__ = "Daniel Ching"
+__copyright__ = "Copyright (c) 2023, UChicago Argonne, LLC."
+__docformat__ = 'restructuredtext en'
+
+
+class Sum(Operator):
+
+    def fwd(self, unsummed, shape):
+        """Perform the forward operator."""
+        return self.xp.sum(unsummed, keepdims=True)
+
+    def adj(self, summed, shape):
+        """Perform the adjoint operator."""
+        return self.xp.ones_like(summed, shape=shape) * summed
+
+
+class TestSum(unittest.TestCase, OperatorTests):
+    """Test the Pad operator."""
+
+    def setUp(self, shape=(7, 5, 5)):
+        """Load a dataset for reconstruction."""
+
+        self.operator = Sum()
+        self.operator.__enter__()
+        self.xp = self.operator.xp
+
+        np.random.seed(0)
+        self.m = self.xp.asarray(random_complex(*shape))
+        self.m_name = 'unsummed'
+        self.d = self.xp.asarray(random_complex(*(1, 1, 1)))
+        self.d_name = 'summed'
+        self.kwargs = {
+            'shape': shape,
+        }
+        print(self.operator)
+
+    @unittest.skip('FIXME: This operator is not scaled.')
+    def test_scaled(self):
+        pass
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/operators/test_usfft.py
+++ b/tests/operators/test_usfft.py
@@ -7,6 +7,7 @@ import numpy as np
 from tike.operators.cupy.usfft import (eq2us, us2eq, vector_gather,
                                        vector_scatter)
 from tike.operators import Operator
+import tike.precision
 
 from .util import random_complex, OperatorTests
 
@@ -37,14 +38,14 @@ class TestInterp(unittest.TestCase, OperatorTests):
         self.operator.__enter__()
         self.xp = self.operator.xp
         np.random.seed(0)
-        self.m = self.xp.asarray(random_complex(n, n, n), dtype='complex64')
+        self.m = self.xp.asarray(random_complex(n, n, n))
         self.m_name = 'f'
-        self.d = self.xp.asarray(random_complex(ntheta), dtype='complex64')
+        self.d = self.xp.asarray(random_complex(ntheta))
         self.d_name = 'F'
         self.kwargs = {
             'x':
-                self.xp.asarray(np.random.rand(ntheta, 3) -
-                                0.5).astype('float32'),
+                self.xp.asarray(np.random.rand(ntheta, 3) - 0.5,
+                                dtype=tike.precision.floating),
             'n':
                 n,
         }
@@ -75,14 +76,14 @@ class TestUSFFT(unittest.TestCase, OperatorTests):
         self.operator.__enter__()
         self.xp = self.operator.xp
         np.random.seed(1)
-        self.m = self.xp.asarray(random_complex(n, n, n), dtype='complex64')
+        self.m = self.xp.asarray(random_complex(n, n, n))
         self.m_name = 'f'
-        self.d = self.xp.asarray(random_complex(ntheta), dtype='complex64')
+        self.d = self.xp.asarray(random_complex(ntheta))
         self.d_name = 'F'
         self.kwargs = {
             'x':
-                self.xp.asarray(np.random.rand(ntheta, 3) -
-                                0.5).astype('float32'),
+                self.xp.asarray(np.random.rand(ntheta, 3) - 0.5).astype(
+                    tike.precision.floating),
             'n':
                 n,
         }
@@ -93,7 +94,7 @@ class TestUSFFT(unittest.TestCase, OperatorTests):
         pass
 
     @unittest.skip('For debugging only.')
-    def test_image(self, s=32, ntheta=16 * 16 * 16):
+    def test_image(self, s=64, ntheta=16 * 16 * 16):
         import libimage
         import matplotlib
         matplotlib.use('Agg')
@@ -101,7 +102,7 @@ class TestUSFFT(unittest.TestCase, OperatorTests):
 
         f = libimage.load('satyre', s)
         f = np.tile(f, (s, 1, 1))
-        f = self.xp.asarray(f, dtype='complex64')
+        f = self.xp.asarray(f, dtype=tike.precision.cfloating)
 
         x = [
             g.ravel() for g in np.meshgrid(
@@ -115,16 +116,14 @@ class TestUSFFT(unittest.TestCase, OperatorTests):
 
         print(x.shape)
 
-        x = self.xp.asarray(x, dtype='float32')
+        x = self.xp.asarray(x, dtype=tike.precision.floating)
 
         d = self.operator.fwd(f, x, s)
         m = self.operator.adj(d, x, s)
 
         plt.figure()
         plt.imshow(m[s // 2].real.get())
-        plt.figure()
-        plt.imshow(f[s // 2].real.get())
-        plt.show()
+        plt.savefig('usfft-real.png')
 
 
 if __name__ == '__main__':

--- a/tests/operators/util.py
+++ b/tests/operators/util.py
@@ -50,8 +50,8 @@ class OperatorTests():
         print()
         print('<Fm,   m> = {:.5g}{:+.5g}j'.format(a.real.item(), a.imag.item()))
         print('< d, F*d> = {:.5g}{:+.5g}j'.format(b.real.item(), b.imag.item()))
-        self.xp.testing.assert_allclose(a.real, b.real, rtol=1e-5, atol=0)
-        self.xp.testing.assert_allclose(a.imag, b.imag, rtol=1e-5, atol=0)
+        self.xp.testing.assert_allclose(a.real, b.real, rtol=1e-4, atol=0)
+        self.xp.testing.assert_allclose(a.imag, b.imag, rtol=1e-4, atol=0)
 
     def test_scaled(self):
         """Check that the adjoint operator is scaled."""
@@ -66,7 +66,7 @@ class OperatorTests():
         # NOTE: Inner product with self is real-only magnitude of self
         print('<F*Fm, F*Fm> = {:.5g}{:+.5g}j'.format(a.real.item(), 0))
         print('<   m,    m> = {:.5g}{:+.5g}j'.format(b.real.item(), 0))
-        self.xp.testing.assert_allclose(a.real, b.real, rtol=1e-5, atol=0)
+        self.xp.testing.assert_allclose(a.real, b.real, rtol=1e-4, atol=0)
 
     def test_fwd_time(self):
         """Time the forward operation."""

--- a/tests/operators/util.py
+++ b/tests/operators/util.py
@@ -6,15 +6,18 @@ __author__ = "Daniel Ching, Viktor Nikitin"
 __copyright__ = "Copyright (c) 2020, UChicago Argonne, LLC."
 __docformat__ = 'restructuredtext en'
 
+import tike.linalg
+import tike.random
+import tike.precision
 
-def random_complex(*args):
-    """Return a complex random array in the range (-0.5, 0.5)."""
-    return (np.random.rand(*args) - 0.5 + 1j * (np.random.rand(*args) - 0.5))
+random_complex = tike.random.numpy_complex
 
 
-def inner_complex(x, y):
-    """Return the complex inner product; the order of the operands matters."""
-    return (x.conj() * y).sum()
+def random_floating(*shape):
+    return tike.random.randomizer_np.random(
+        size=shape,
+        dtype=tike.precision.floating,
+    ) - 0.5
 
 
 class OperatorTests():
@@ -42,8 +45,8 @@ class OperatorTests():
         assert d.shape == self.d.shape, (d.shape, self.d.shape)
         m = self.operator.adj(**{self.d_name: self.d}, **self.kwargs)
         assert m.shape == self.m.shape, (m.shape, self.m.shape)
-        a = inner_complex(d, self.d)
-        b = inner_complex(self.m, m)
+        a = tike.linalg.inner(d, self.d)
+        b = tike.linalg.inner(self.m, m)
         print()
         print('<Fm,   m> = {:.5g}{:+.5g}j'.format(a.real.item(), a.imag.item()))
         print('< d, F*d> = {:.5g}{:+.5g}j'.format(b.real.item(), b.imag.item()))
@@ -57,8 +60,8 @@ class OperatorTests():
         # all of our operators. Here we only test whether |F*Fm| = |m|.
         d = self.operator.fwd(**{self.m_name: self.m}, **self.kwargs)
         m = self.operator.adj(**{self.d_name: d}, **self.kwargs)
-        a = inner_complex(m, m)
-        b = inner_complex(self.m, self.m)
+        a = tike.linalg.inner(m, m)
+        b = tike.linalg.inner(self.m, self.m)
         print()
         # NOTE: Inner product with self is real-only magnitude of self
         print('<F*Fm, F*Fm> = {:.5g}{:+.5g}j'.format(a.real.item(), 0))

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -26,7 +26,7 @@ def test_lstsq():
     )
     b = a @ x
     x1 = tike.linalg.lstsq(a, b, weights=w)
-    cp.testing.assert_allclose(x1, x, atol=1e-3)
+    cp.testing.assert_allclose(x1, x, rtol=1e-2, atol=0)
 
 
 def test_projection():

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -4,6 +4,7 @@ import cupy as cp
 
 import tike.linalg
 import tike.random
+import tike.precision
 
 
 def test_norm():
@@ -19,10 +20,13 @@ def test_norm():
 def test_lstsq():
     a = tike.random.cupy_complex(5, 1, 4, 3, 3)
     x = tike.random.cupy_complex(5, 1, 4, 3, 1)
-    w = cp.random.rand(5, 1, 4, 3)
+    w = tike.random.randomizer_cp.random(
+        size=(5, 1, 4, 3),
+        dtype=tike.precision.floating,
+    )
     b = a @ x
     x1 = tike.linalg.lstsq(a, b, weights=w)
-    cp.testing.assert_allclose(x1, x)
+    cp.testing.assert_allclose(x1, x, atol=1e-3)
 
 
 def test_projection():
@@ -31,8 +35,8 @@ def test_projection():
     b = tike.random.cupy_complex(5)
     pab = tike.linalg.projection(a, b)
     pba = tike.linalg.projection(b, a)
-    assert abs(tike.linalg.inner(a - pab, b)) < 1e-12
-    assert abs(tike.linalg.inner(a, b - pba)) < 1e-12
+    assert abs(tike.linalg.inner(a - pab, b)) < 1e-6
+    assert abs(tike.linalg.inner(a, b - pba)) < 1e-6
 
 
 class Orthogonal(unittest.TestCase):
@@ -62,4 +66,4 @@ class Orthogonal(unittest.TestCase):
                         u[:, j:j + 1],
                         axis=axis,
                     ))
-                assert cp.all(error < 1e-12)
+                assert cp.all(error < 1e-6)


### PR DESCRIPTION
<!--Thank you for opening a pull request!

We appreciate that you care about this project enough to fix it, and we welcome contributions. We will make every effort to review your pull request in a timely manner. Please help us by following the instructions below.
-->

## Purpose
<!--Describe the problem or feature.

Only address one feature per pull request. If the scope of a single pull request is small (less than 400 lines of code), reviewers can understand it more quickly.

Link to any existing Issues. Use the `Closes` keyword if this Pull closes any Issues.
-->
Increase the available precision options for all of the implemented Operators. This allows users to use 64bit floating types or mix 32bit and 64bit types without causing errors to be raised.

## Approach
<!--Describe how your changes address the problem.

Provide a brief summary of your algorithm(s) here.
-->
Use CXX templates to compile the operator CUDA kernels for multiple input types. Using CuPy RawModule and runtime type introspections we can then match the cupy data types with the RawKernels compiled for those types.

The default precision of most functions is now controlled by the tike.precision module. Not sure whether this can be changed at runtime or not.


## Pre-Merge Checklists

### Submitter
- [x] Write a helpfully descriptive pull request title.
- [x] Organize changes into logically grouped commits with descriptive commit messages.
- [ ] Document all new functions.
- [ ] Click 'details' on the readthedocs check to view the updated docs.
- [ ] Write tests for new functions or explain why they are not needed.
- [ ] Address any complaints from pep8speaks.

### Reviewer
- [ ] Actually read all of the code.
- [ ] Run the new code yourself; the included tests should make this easy.
- [ ] Write a summary of the changes as you understand them.
- [ ] Thank the submitter.
