### PR TITLE
NEW: Trim memory pool at the end of reconstruction

### DIFF
--- a/src/tike/ptycho/ptycho.py
+++ b/src/tike/ptycho/ptycho.py
@@ -525,9 +525,14 @@ class Reconstruction():
 
     def __exit__(self, type, value, traceback):
         self._get_result()
+        self._device_parameters = None
         self.comm.__exit__(type, value, traceback)
         self.operator.__exit__(type, value, traceback)
         self.device.__exit__(type, value, traceback)
+        mempool = cp.get_default_memory_pool()
+        mempool.free_all_blocks()
+        pinned_mempool = cp.get_default_pinned_memory_pool()
+        pinned_mempool.free_all_blocks()
 
     def get_convergence(
         self

--- a/src/tike/ptycho/ptycho.py
+++ b/src/tike/ptycho/ptycho.py
@@ -318,7 +318,7 @@ class Reconstruction():
 
         self.data = data
         self.parameters = parameters
-        self._device_parameters = copy.deepcopy(parameters)
+        self._device_parameters = None
         self.device = cp.cuda.Device(
             num_gpu[0] if isinstance(num_gpu, tuple) else None)
         self.operator = tike.operators.Ptycho(
@@ -334,6 +334,8 @@ class Reconstruction():
         self.device.__enter__()
         self.operator.__enter__()
         self.comm.__enter__()
+
+        self._device_parameters = copy.deepcopy(self.parameters)
 
         # Divide the inputs into regions
         if (not np.all(np.isfinite(self.data)) or np.any(self.data < 0)):


### PR DESCRIPTION
<!--Thank you for opening a pull request!

We appreciate that you care about this project enough to fix it, and we welcome contributions. We will make every effort to review your pull request in a timely manner. Please help us by following the instructions below.
-->

## Purpose
<!--Describe the problem or feature.

Only address one feature per pull request. If the scope of a single pull request is small (less than 400 lines of code), reviewers can understand it more quickly.

Link to any existing Issues. Use the `Closes` keyword if this Pull closes any Issues.
-->
By default, CuPy uses a memory pool instead of allocating a unique block of memory for every array created. This means that CuPy will continue to reserve GPU memory on a device even if all the CuPy arrays are destroyed. This causes a small reconstruction after a large reconstruction in the same script to use the same amount of memory.

## Approach
<!--Describe how your changes address the problem.

Provide a brief summary of your algorithm(s) here.
-->
Ask the memory pool to trim itself to the only actively used memory at the end of a reconstruction.

Users could also manually disable the memory pool [1], then I guess CuPy makes memory allocations that are tied to the life of each array.

[1] https://docs.cupy.dev/en/stable/user_guide/memory.html#memory-pool-operations

## Pre-Merge Checklists

### Submitter
- [x] Write a helpfully descriptive pull request title.
- [x] Organize changes into logically grouped commits with descriptive commit messages.
- [x] Document all new functions.
- [x] Click 'details' on the readthedocs check to view the updated docs.
- [x] Write tests for new functions or explain why they are not needed.
- [x] Address any complaints from pep8speaks.

### Reviewer
- [ ] Actually read all of the code.
- [ ] Run the new code yourself; the included tests should make this easy.
- [ ] Write a summary of the changes as you understand them.
- [ ] Thank the submitter.
