### PR TITLE
API: Remove redundant `model` parameter

### DIFF
--- a/docs/source/api/operators.rst
+++ b/docs/source/api/operators.rst
@@ -1,25 +1,41 @@
 operators
 =========
 .. automodule:: tike.operators
-   :no-members:
-
-.. automodule:: tike.operators.cupy
-   :inherited-members:
    :members:
-   :show-inheritance:
    :undoc-members:
 
    .. autosummary::
-      :nosignatures:
-
       Operator
       Alignment
+      Bucket
       CachedFFT
       Convolution
       Flow
       Lamino
       Pad
+      Patch
       Propagation
       Ptycho
       Rotate
       Shift
+
+.. autoclass:: Alignment
+.. autoclass:: Bucket
+.. autoclass:: CachedFFT
+.. autoclass:: Convolution
+.. autoclass:: Flow
+.. autoclass:: Lamino
+.. autoclass:: Operator
+.. autoclass:: Pad
+.. autoclass:: Patch
+.. autoclass:: Propagation
+.. autoclass:: Ptycho
+.. autoclass:: Rotate
+.. autoclass:: Shift
+
+.. autofunction:: gaussian
+.. autofunction:: gaussian_each_pattern
+.. autofunction:: gaussian_grad
+.. autofunction:: poisson
+.. autofunction:: poisson_each_pattern
+.. autofunction:: poisson_grad

--- a/src/tike/operators/cupy/propagation.py
+++ b/src/tike/operators/cupy/propagation.py
@@ -36,9 +36,9 @@ class Propagation(CachedFFT, Operator):
         functions and gradients is (nscan, 1, 1, detector_shape,
         detector_shape).
 
-    .. versionchanged:: 0.25.0
-    Removed the model parameter and the cost(), grad() functions. Use the cost
-    and gradient functions directly instead.
+
+    .. versionchanged:: 0.25.0 Removed the model parameter and the cost(),
+        grad() functions. Use the cost and gradient functions directly instead.
 
     """
 

--- a/src/tike/operators/cupy/propagation.py
+++ b/src/tike/operators/cupy/propagation.py
@@ -22,8 +22,6 @@ class Propagation(CachedFFT, Operator):
     ----------
     detector_shape : int
         The pixel width and height of the nearplane and farplane waves.
-    model : string
-        The type of noise model to use for the cost functions.
     cost : (data-like, farplane-like) -> float
         The function to be minimized when solving a problem.
     grad : (data-like, farplane-like) -> farplane-like
@@ -34,17 +32,18 @@ class Propagation(CachedFFT, Operator):
     nearplane: (..., detector_shape, detector_shape) complex64
         The wavefronts after exiting the object.
     farplane: (..., detector_shape, detector_shape) complex64
-        The wavefronts hitting the detector respectively.
-        Shape for cost functions and gradients is
-        (nscan, 1, 1, detector_shape, detector_shape).
+        The wavefronts hitting the detector respectively. Shape for cost
+        functions and gradients is (nscan, 1, 1, detector_shape,
+        detector_shape).
+
+    .. versionchanged:: 0.25.0
+    Removed the model parameter and the cost(), grad() functions. Use the cost
+    and gradient functions directly instead.
 
     """
 
-    def __init__(self, detector_shape: int, model: str = 'gaussian', **kwargs):
+    def __init__(self, detector_shape: int, **kwargs):
         self.detector_shape = detector_shape
-        self.cost = getattr(objective, f'{model}')
-        self.grad = getattr(objective, f'{model}_grad')
-        self.model = model
 
     def fwd(
         self,

--- a/src/tike/operators/cupy/ptycho.py
+++ b/src/tike/operators/cupy/ptycho.py
@@ -47,8 +47,8 @@ class Ptycho(Operator):
         measurement in the coordinate system of psi. Coordinate order
         consistent with WIDE, HIGH order.
 
-    .. versionchanged:: 0.25.0
-    Removed the model and ntheta parameters.
+
+    .. versionchanged:: 0.25.0 Removed the model and ntheta parameters.
 
     """
 

--- a/src/tike/operators/cupy/ptycho.py
+++ b/src/tike/operators/cupy/ptycho.py
@@ -11,7 +11,7 @@ import numpy as np
 from .operator import Operator
 from .propagation import Propagation
 from .convolution import Convolution
-
+from . import objective
 
 class Ptycho(Operator):
     """A Ptychography operator.
@@ -33,9 +33,6 @@ class Ptycho(Operator):
         The wave propagation operator being used.
     diffraction : :py:class:`Operator`
         The object probe interaction operator being used.
-    model : string
-        The type of noise model to use for the cost functions.
-
     data : (..., FRAME, WIDE, HIGH) float32
         The intensity (square of the absolute value) of the propagated
         wavefront; i.e. what the detector records.
@@ -50,6 +47,9 @@ class Ptycho(Operator):
         measurement in the coordinate system of psi. Coordinate order
         consistent with WIDE, HIGH order.
 
+    .. versionchanged:: 0.25.0
+    Removed the model and ntheta parameters.
+
     """
 
     def __init__(
@@ -58,8 +58,6 @@ class Ptycho(Operator):
         probe_shape: int,
         nz: int,
         n: int,
-        ntheta: int = 1,
-        model: str = 'gaussian',
         propagation: typing.Type[Propagation] = Propagation,
         diffraction: typing.Type[Convolution] = Convolution,
         **kwargs,
@@ -67,7 +65,6 @@ class Ptycho(Operator):
         """Please see help(Ptycho) for more info."""
         self.propagation = propagation(
             detector_shape=detector_shape,
-            model=model,
             **kwargs,
         )
         self.diffraction = diffraction(
@@ -173,10 +170,12 @@ class Ptycho(Operator):
         psi: npt.NDArray[np.csingle],
         scan: npt.NDArray[np.single],
         probe: npt.NDArray[np.csingle],
+        *,
+        model: str,
     ) -> float:
         """Please see help(Ptycho) for more info."""
         intensity, _ = self._compute_intensity(data, psi, scan, probe)
-        return self.propagation.cost(data, intensity)
+        return getattr(objective, model)(data, intensity)
 
     def grad_psi(
         self,
@@ -184,12 +183,14 @@ class Ptycho(Operator):
         psi: npt.NDArray[np.csingle],
         scan: npt.NDArray[np.single],
         probe: npt.NDArray[np.csingle],
+        *,
+        model: str,
     ) -> npt.NDArray[np.csingle]:
         """Please see help(Ptycho) for more info."""
         intensity, farplane = self._compute_intensity(data, psi, scan, probe)
         grad_obj = self.xp.zeros_like(psi)
         grad_obj = self.adj(
-            farplane=self.propagation.grad(
+            farplane=getattr(objective, f'{model}_grad')(
                 data,
                 farplane,
                 intensity,
@@ -208,6 +209,8 @@ class Ptycho(Operator):
         scan: npt.NDArray[np.single],
         probe: npt.NDArray[np.csingle],
         mode: typing.List[int] = None,
+        *,
+        model: str,
     ) -> npt.NDArray[np.csingle]:
         """Compute the gradient with respect to the probe(s).
 
@@ -222,7 +225,7 @@ class Ptycho(Operator):
         # Use the average gradient for all probe positions
         return self.xp.mean(
             self.adj_probe(
-                farplane=self.propagation.grad(
+                farplane=getattr(objective, f'{model}_grad')(
                     data,
                     farplane[..., mode, :, :],
                     intensity,

--- a/src/tike/ptycho/exitwave.py
+++ b/src/tike/ptycho/exitwave.py
@@ -22,7 +22,11 @@ logger = logging.getLogger(__name__)
 
 @dataclasses.dataclass
 class ExitWaveOptions:
-    """Manage data and setting related to exitwave updates."""
+    """Manage data and setting related to exitwave updates.
+
+    .. versionadded:: 0.25.0
+
+    """
 
     measured_pixels: npt.NDArray
     """

--- a/src/tike/ptycho/ptycho.py
+++ b/src/tike/ptycho/ptycho.py
@@ -203,9 +203,9 @@ def reconstruct(
     use_mpi : bool
         Whether to use MPI or not.
 
-    .. versionchanged:: 0.25.0
-    Removed the model parameter. Use :py:class:`tike.ptycho.ExitwaveOptions`
-    instead.
+
+    .. versionchanged:: 0.25.0 Removed the `model` parameter. Use
+        :py:class:`tike.ptycho.exitwave.ExitwaveOptions` instead.
 
     Raises
     ------

--- a/src/tike/ptycho/ptycho.py
+++ b/src/tike/ptycho/ptycho.py
@@ -179,7 +179,6 @@ def simulate(
 def reconstruct(
     data: npt.NDArray,
     parameters: solvers.PtychoParameters,
-    model: str = 'gaussian',
     num_gpu: typing.Union[int, typing.Tuple[int, ...]] = 1,
     use_mpi: bool = False,
 ) -> solvers.PtychoParameters:
@@ -197,14 +196,16 @@ def reconstruct(
         diffraction peak is at the corners.
     parameters: :py:class:`tike.ptycho.solvers.PtychoParameters`
         A class containing reconstruction parameters.
-    model : "gaussian", "poisson"
-        The noise model to use for the cost function.
     num_gpu : int, tuple(int)
         The number of GPUs to use or a tuple of the device numbers of the GPUs
         to use. If the number of GPUs is less than the requested number, only
         workers for the available GPUs are allocated.
     use_mpi : bool
         Whether to use MPI or not.
+
+    .. versionchanged:: 0.25.0
+    Removed the model parameter. Use :py:class:`tike.ptycho.ExitwaveOptions`
+    instead.
 
     Raises
     ------
@@ -222,7 +223,6 @@ def reconstruct(
     with Reconstruction(
             data,
             parameters,
-            model,
             num_gpu,
             use_mpi,
     ) as context:
@@ -257,7 +257,6 @@ class Reconstruction():
         with tike.ptycho.Reconstruction(
             data,
             parameters,
-            model,
             num_gpu,
             use_mpi,
         ) as context:
@@ -277,7 +276,6 @@ class Reconstruction():
         self,
         data: npt.NDArray,
         parameters: solvers.PtychoParameters,
-        model: str = 'gaussian',
         num_gpu: typing.Union[int, typing.Tuple[int, ...]] = 1,
         use_mpi: bool = False,
     ):
@@ -326,7 +324,6 @@ class Reconstruction():
             detector_shape=data.shape[-1],
             nz=parameters.psi.shape[-2],
             n=parameters.psi.shape[-1],
-            model=model,
         )
         self.comm = tike.communicators.Comm(num_gpu, mpi)
 
@@ -771,7 +768,6 @@ def _rescale_probe(operator, comm, data, exitwave_options, psi, scan, probe, num
 def reconstruct_multigrid(
     data: npt.NDArray,
     parameters: solvers.PtychoParameters,
-    model: str = 'gaussian',
     num_gpu: typing.Union[int, typing.Tuple[int, ...]] = 1,
     use_mpi: bool = False,
     num_levels: int = 3,
@@ -812,7 +808,6 @@ def reconstruct_multigrid(
                 ),
                 parameters=resampled_parameters,
                 num_gpu=num_gpu,
-                model=model,
                 use_mpi=use_mpi,
         ) as context:
             context.iterate(resampled_parameters.algorithm_options.num_iter)

--- a/src/tike/ptycho/solvers/adam.py
+++ b/src/tike/ptycho/solvers/adam.py
@@ -81,6 +81,7 @@ def adam_grad(
             bscan,
             parameters.probe,
             op=op,
+            model=parameters.exitwave_options.noise_model,
         )))
 
         cost = comm.Allreduce_mean(cost, axis=None).get()
@@ -155,6 +156,7 @@ def _grad_all(
     *,
     mode: typing.Union[None, typing.List[int]] = None,
     op: tike.operators.Ptycho,
+    model: str,
 ) -> typing.Tuple[npt.NDArray, npt.NDArray, npt.NDArray, npt.NDArray]:
     """Compute the gradient with respect to probe(s) and object.
 
@@ -171,9 +173,9 @@ def _grad_all(
         scan,
         probe,
     )
-    cost = op.propagation.cost(data, intensity)
+    cost = getattr(tike.operators, model)(data, intensity)
     grad_psi, grad_probe, amp_psi, amp_probe = op.adj_all(
-        farplane=op.propagation.grad(
+        farplane=getattr(tike.operators, f'{model}_grad')(
             data,
             farplane[..., mode, :, :],
             intensity,

--- a/src/tike/ptycho/solvers/lstsq.py
+++ b/src/tike/ptycho/solvers/lstsq.py
@@ -294,7 +294,7 @@ def _update_wavefront(
         axis=list(range(1, farplane.ndim - 2)),
     )
 
-    costs = getattr(tike.operators, f'{op.propagation.model}_each_pattern')(
+    costs = getattr(tike.operators, f'{exitwave_options.noise_model}_each_pattern')(
         data[:, measured_pixels][:, None, :],
         intensity[:, measured_pixels][:, None, :])
 

--- a/src/tike/ptycho/solvers/rpie.py
+++ b/src/tike/ptycho/solvers/rpie.py
@@ -374,7 +374,7 @@ def _update_wavefront(
         axis=list(range(1, farplane.ndim - 2)),
     )
 
-    cost = getattr(tike.operators, f'{op.propagation.model}_each_pattern')(
+    cost = getattr(tike.operators, f'{exitwave_options.noise_model}_each_pattern')(
         data[:, measured_pixels][:, None, :],
         intensity[:, measured_pixels][:, None, :],
     )


### PR DESCRIPTION
This parameter is redudant with ExitwaveOptions noise_model.

<!--Thank you for opening a pull request!

We appreciate that you care about this project enough to fix it, and we welcome contributions. We will make every effort to review your pull request in a timely manner. Please help us by following the instructions below.
-->

## Purpose
<!--Describe the problem or feature.

Only address one feature per pull request. If the scope of a single pull request is small (less than 400 lines of code), reviewers can understand it more quickly.

Link to any existing Issues. Use the `Closes` keyword if this Pull closes any Issues.
-->
In a recent PR, a new method for specifying the noise model was introduced via the `noise_model` parameter of the `ExitwaveOptions` class. This PR removes the previous method of choosing the noise model, so that there are not two methods.

## Approach
<!--Describe how your changes address the problem.

Provide a brief summary of your algorithm(s) here.
-->

## Pre-Merge Checklists

### Submitter
- [ ] Write a helpfully descriptive pull request title.
- [ ] Organize changes into logically grouped commits with descriptive commit messages.
- [ ] Document all new functions.
- [ ] Click 'details' on the readthedocs check to view the updated docs.
- [ ] Write tests for new functions or explain why they are not needed.
- [ ] Address any complaints from pep8speaks.

### Reviewer
- [ ] Actually read all of the code.
- [ ] Run the new code yourself; the included tests should make this easy.
- [ ] Write a summary of the changes as you understand them.
- [ ] Thank the submitter.
