### PR TITLE
BUG: Don't initialize CUDA Streams at import time

### DIFF
--- a/src/tike/communicators/stream.py
+++ b/src/tike/communicators/stream.py
@@ -10,7 +10,7 @@ def stream_and_reduce(
     args: typing.List[npt.NDArray],
     y_shapes: typing.List[typing.List[int]],
     y_dtypes: typing.List[npt.DTypeLike],
-    streams: typing.List[cp.cuda.Stream] = [cp.cuda.Stream(), cp.cuda.Stream()],
+    streams: typing.List[cp.cuda.Stream] = [],
     indices: typing.Union[None, typing.List[int]] = None,
     *,
     chunk_size: int = 64,
@@ -66,9 +66,11 @@ def stream_and_reduce(
         result = [np.sum(y, axis=0) for y in zip(*[f(*x) for x in zip(*args)])]
 
     """
+    if not streams:
+        streams = [cp.cuda.Stream(), cp.cuda.Stream()]
     if indices is None:
         N = len(args[0])
-        indices = range(N)
+        indices = list(range(N))
     else:
         N = len(indices)
     chunk_size = min(chunk_size, N)
@@ -121,7 +123,7 @@ def stream_and_modify(
     ],
     ind_args: typing.List[npt.NDArray],
     mod_args: typing.Tuple,
-    streams: typing.List[cp.cuda.Stream] = [cp.cuda.Stream(), cp.cuda.Stream()],
+    streams: typing.List[cp.cuda.Stream] = [],
     indices: typing.Union[None, typing.List[int]] = None,
     *,
     chunk_size: int = 64,
@@ -181,6 +183,8 @@ def stream_and_modify(
         assert mod_args == truth
 
     """
+    if not streams:
+        streams = [cp.cuda.Stream(), cp.cuda.Stream()]
     if indices is None:
         N = len(ind_args[0])
         indices = list(range(N))
@@ -233,7 +237,7 @@ def stream_and_modify_debug(
     ],
     ind_args: typing.List[npt.NDArray],
     mod_args: typing.Tuple,
-    streams: typing.List[cp.cuda.Stream] = [cp.cuda.Stream(), cp.cuda.Stream()],
+    streams: typing.List[cp.cuda.Stream] = [],
     indices: typing.Union[None, typing.List[int]] = None,
     *,
     chunk_size: int = 64,
@@ -258,6 +262,8 @@ def stream_and_modify_debug(
         The number of slices out of N to process at one time
 
     """
+    if not streams:
+        streams = [cp.cuda.Stream(), cp.cuda.Stream()]
     if indices is None:
         N = len(ind_args[0])
         indices = list(range(N))


### PR DESCRIPTION
<!--Thank you for opening a pull request!

We appreciate that you care about this project enough to fix it, and we welcome contributions. We will make every effort to review your pull request in a timely manner. Please help us by following the instructions below.
-->

## Purpose
<!--Describe the problem or feature.

Only address one feature per pull request. If the scope of a single pull request is small (less than 400 lines of code), reviewers can understand it more quickly.

Link to any existing Issues. Use the `Closes` keyword if this Pull closes any Issues.
-->
Prevent GPU memory from being allocated at import time on the 0th GPU.

## Approach
<!--Describe how your changes address the problem.

Provide a brief summary of your algorithm(s) here.
-->
Streams take GPU memory and may be unused if only non-GPU functions are used, so wait until functions are called to do initialization.

## Pre-Merge Checklists

### Submitter
- [x] Write a helpfully descriptive pull request title.
- [x] Organize changes into logically grouped commits with descriptive commit messages.
- [ ] Document all new functions.
- [ ] Click 'details' on the readthedocs check to view the updated docs.
- [ ] Write tests for new functions or explain why they are not needed.
- [ ] Address any complaints from pep8speaks.

### Reviewer
- [ ] Actually read all of the code.
- [ ] Run the new code yourself; the included tests should make this easy.
- [ ] Write a summary of the changes as you understand them.
- [ ] Thank the submitter.
