### PR TITLE
NEW: Allow enabling limits for probe position update magnitude

### DIFF
--- a/src/tike/ptycho/position.py
+++ b/src/tike/ptycho/position.py
@@ -326,9 +326,9 @@ class PositionOptions:
     """Whether the positions are constrained to fit a random error plus affine
     error model."""
 
-    update_clipping: float = 0
-    """Clipping value for position update. When set to a positive number, x/y
-    update magnitudes beyond the set value are clipped to this value."""
+    update_magnitude_limit: float = 0
+    """When set to a positive number, x and y update magnitudes are clipped
+    (limited) to this value."""
 
     transform: AffineTransform = AffineTransform()
     """Global transform of positions."""
@@ -389,7 +389,7 @@ class PositionOptions:
             vdecay=self.vdecay,
             mdecay=self.mdecay,
             use_position_regularization=self.use_position_regularization,
-            update_clipping=self.update_clipping,
+            update_magnitude_limit=self.update_magnitude_limit,
             transform=self.transform,
         )
         if self.use_adaptive_moment:
@@ -404,7 +404,7 @@ class PositionOptions:
             vdecay=self.vdecay,
             mdecay=self.mdecay,
             use_position_regularization=self.use_position_regularization,
-            update_clipping=self.update_clipping,
+            update_magnitude_limit=self.update_magnitude_limit,
             transform=self.transform,
         )
         if self.confidence is not None:
@@ -479,7 +479,7 @@ class PositionOptions:
             vdecay=self.vdecay,
             mdecay=self.mdecay,
             use_position_regularization=self.use_position_regularization,
-            update_clipping=self.update_clipping,
+            update_magnitude_limit=self.update_magnitude_limit,
             transform=self.transform,
             confidence=self.confidence,
         )

--- a/src/tike/ptycho/position.py
+++ b/src/tike/ptycho/position.py
@@ -327,7 +327,7 @@ class PositionOptions:
     error model."""
 
     update_clipping: float = 0
-    """Clipping value for position update. When set to a positive number, x/y 
+    """Clipping value for position update. When set to a positive number, x/y
     update magnitudes beyond the set value are clipped to this value."""
 
     transform: AffineTransform = AffineTransform()

--- a/src/tike/ptycho/position.py
+++ b/src/tike/ptycho/position.py
@@ -326,6 +326,11 @@ class PositionOptions:
     """Whether the positions are constrained to fit a random error plus affine
     error model."""
 
+    update_clipping: float = 0
+    """Clipping value for position update. When set to a positive number, x/y update
+    magnitudes beyond the set value are clipped to this value. 
+    """
+
     transform: AffineTransform = AffineTransform()
     """Global transform of positions."""
 
@@ -385,6 +390,7 @@ class PositionOptions:
             vdecay=self.vdecay,
             mdecay=self.mdecay,
             use_position_regularization=self.use_position_regularization,
+            update_clipping=self.update_clipping,
             transform=self.transform,
         )
         if self.use_adaptive_moment:
@@ -399,6 +405,7 @@ class PositionOptions:
             vdecay=self.vdecay,
             mdecay=self.mdecay,
             use_position_regularization=self.use_position_regularization,
+            update_clipping=self.update_clipping,
             transform=self.transform,
         )
         if self.confidence is not None:
@@ -473,6 +480,7 @@ class PositionOptions:
             vdecay=self.vdecay,
             mdecay=self.mdecay,
             use_position_regularization=self.use_position_regularization,
+            update_clipping=self.update_clipping,
             transform=self.transform,
             confidence=self.confidence,
         )

--- a/src/tike/ptycho/position.py
+++ b/src/tike/ptycho/position.py
@@ -327,9 +327,8 @@ class PositionOptions:
     error model."""
 
     update_clipping: float = 0
-    """Clipping value for position update. When set to a positive number, x/y update
-    magnitudes beyond the set value are clipped to this value. 
-    """
+    """Clipping value for position update. When set to a positive number, x/y 
+    update magnitudes beyond the set value are clipped to this value."""
 
     transform: AffineTransform = AffineTransform()
     """Global transform of positions."""

--- a/src/tike/ptycho/solvers/lstsq.py
+++ b/src/tike/ptycho/solvers/lstsq.py
@@ -891,6 +891,13 @@ def _update_position(
         (1 - alpha) * position_update_denominator +
         alpha * max(position_update_denominator.max(), 1e-6))
 
+    if position_options.update_magnitude_limit > 0:
+        step = cp.clip(
+            step,
+            a_min=-position_options.update_magnitude_limit,
+            a_max=position_options.update_magnitude_limit,
+        )
+
     if position_options.use_adaptive_moment:
         (
             step,

--- a/src/tike/ptycho/solvers/rpie.py
+++ b/src/tike/ptycho/solvers/rpie.py
@@ -1,6 +1,7 @@
 import logging
 
 import cupy as cp
+import numpy as np
 import numpy.typing as npt
 
 import tike.communicators
@@ -561,6 +562,10 @@ def _update_position(
     step = (position_update_numerator) / (
         (1 - alpha) * position_update_denominator +
         alpha * max(position_update_denominator.max(), 1e-6))
+
+    if position_options.update_clipping > 0:
+        clip_val = position_options.update_clipping
+        step = np.clip(step, a_min=-clip_val, a_max=clip_val)
 
     if position_options.use_adaptive_moment:
         (

--- a/src/tike/ptycho/solvers/rpie.py
+++ b/src/tike/ptycho/solvers/rpie.py
@@ -1,7 +1,6 @@
 import logging
 
 import cupy as cp
-import numpy as np
 import numpy.typing as npt
 
 import tike.communicators
@@ -574,9 +573,12 @@ def _update_position(
         (1 - alpha) * position_update_denominator +
         alpha * max(position_update_denominator.max(), 1e-6))
 
-    if position_options.update_clipping > 0:
-        clip_val = position_options.update_clipping
-        step = np.clip(step, a_min=-clip_val, a_max=clip_val)
+    if position_options.update_magnitude_limit > 0:
+        step = cp.clip(
+            step,
+            a_min=-position_options.update_magnitude_limit,
+            a_max=position_options.update_magnitude_limit,
+        )
 
     if position_options.use_adaptive_moment:
         (

--- a/tests/ptycho/test_position.py
+++ b/tests/ptycho/test_position.py
@@ -290,6 +290,7 @@ class PtychoPosition(ReconstructTwice, CNMPositionSetup):
                 self.scan,
                 use_adaptive_moment=True,
                 use_position_regularization=True,
+                update_magnitude_limit=5,
             ),
         )
 


### PR DESCRIPTION
## Purpose
Implement a guardrail for probe position updates. When the magnitude of x/y update is larger than
a user-specified value, clip the update to that value. 

## Approach
1. Added `update_magnitude_limit` in `PositionOptions`. 
2. In `rpie._update_position`, clip values `step` if their magnitude is larger than `position_options.update_magnitude_limit`. 
