### PR TITLE
API: Remove tike.random.randomizer_cp to prevent context on unused devices

### DIFF
--- a/src/tike/random.py
+++ b/src/tike/random.py
@@ -8,7 +8,6 @@ import numpy as np
 import tike.precision
 
 randomizer_np = np.random.default_rng()
-randomizer_cp = cp.random.default_rng()
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +22,7 @@ def numpy_complex(*shape):
 def cupy_complex(*shape):
     """Return a complex random array in the range [-0.5, 0.5)."""
     return (
-        randomizer_cp.random(size=(*shape, 2), dtype=tike.precision.floating) -
+        cp.random.random(size=(*shape, 2), dtype=tike.precision.floating) -
         0.5).view(tike.precision.cfloating)[..., 0]
 
 

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -25,7 +25,7 @@ def test_norm():
 def test_lstsq():
     a = tike.random.cupy_complex(5, 1, 4, 3, 3)
     x = tike.random.cupy_complex(5, 1, 4, 3, 1)
-    w = tike.random.randomizer_cp.random(
+    w = cp.random.random(
         size=(5, 1, 4, 3),
         dtype=tike.precision.floating,
     )


### PR DESCRIPTION

<!--Thank you for opening a pull request!

We appreciate that you care about this project enough to fix it, and we welcome contributions. We will make every effort to review your pull request in a timely manner. Please help us by following the instructions below.
-->

## Purpose
<!--Describe the problem or feature.

Only address one feature per pull request. If the scope of a single pull request is small (less than 400 lines of code), reviewers can understand it more quickly.

Link to any existing Issues. Use the `Closes` keyword if this Pull closes any Issues.
-->
Creating a randomization generator opens a CUDA context on the current device, but we don't want that because the default device might not be used.
## Approach
<!--Describe how your changes address the problem.

Provide a brief summary of your algorithm(s) here.
-->
Switch back to the functional API which creates a new random state generator on-demand for every function call? Even though this API is deprecated due to less good randomness.

## Pre-Merge Checklists

### Submitter
- [ ] Write a helpfully descriptive pull request title.
- [ ] Organize changes into logically grouped commits with descriptive commit messages.
- [ ] Document all new functions.
- [ ] Click 'details' on the readthedocs check to view the updated docs.
- [ ] Write tests for new functions or explain why they are not needed.
- [ ] Address any complaints from pep8speaks.

### Reviewer
- [ ] Actually read all of the code.
- [ ] Run the new code yourself; the included tests should make this easy.
- [ ] Write a summary of the changes as you understand them.
- [ ] Thank the submitter.
