### PR TITLE
NEW: Optional median filtering of probe "hot spots"

### DIFF
--- a/src/tike/ptycho/probe.py
+++ b/src/tike/ptycho/probe.py
@@ -887,13 +887,16 @@ def constrain_center_peak(probe):
     probe = stack.reshape(probe.shape)
     return probe
 
-def apply_median_filter_abs_probe( probe, med_filt_px ):
-    
+
+def apply_median_filter_abs_probe(
+    probe: npt.NDArray[cp.complex64],
+    med_filt_px: typing.Tuple[float, float],
+) -> npt.NDArray[cp.complex64]:
     """Apply a median filter to each of the shared probe modes.
 
-    This is meant as a "quick fix" to the probe "hot spots" 
+    This is meant as a "quick fix" to the probe "hot spots"
     numerical artifacts that arise due to the sample * probe
-    scaling ambiguity we have in phase retrieval under the 
+    scaling ambiguity we have in phase retrieval under the
     projection approximation.
 
     Parameters
@@ -901,17 +904,26 @@ def apply_median_filter_abs_probe( probe, med_filt_px ):
     probe : ( 1, 1, SHARED, WIDE, HIGH) complex64
         The shared probes amongst all positions.
     med_filt_px : typing.Tuple[float, float]
-        A two element array like (tuple or list) with 
-        the median filter pixel widths 
+        A two element array like (tuple or list) with
+        the median filter pixel widths
+
+    Returns
+    -------
+    probe : the filtered probe modified in-place.
     """
 
-    abs_probe = cp.abs( probe[ 0, 0, ... ] )
+    abs_probe = cp.abs(probe[0, 0, ...])
 
-    abs_probe = cupyx.scipy.ndimage.median_filter( input = abs_probe, size = ( 1.0, *med_filt_px ), mode = 'constant' )
-    
-    probe[ 0, 0, ... ] = abs_probe * cp.exp( 1j * cp.angle( probe[ 0, 0, ... ] )) 
+    abs_probe = cupyx.scipy.ndimage.median_filter(
+        input=abs_probe,
+        size=(1.0, *med_filt_px),
+        mode="constant",
+    )
+
+    probe[0, 0, ...] = abs_probe * cp.exp(1j * cp.angle(probe[0, 0, ...]))
 
     return probe
+
 
 def constrain_probe_sparsity(probe, f):
     """Constrain the probe intensity so at least `f` fraction elements are zero."""

--- a/src/tike/ptycho/probe.py
+++ b/src/tike/ptycho/probe.py
@@ -138,6 +138,20 @@ class ProbeOptions:
     hard constraint.
     """
 
+    median_filter_abs_probe: bool = False
+    """ Binary switch on whether to apply a median filter to absolute value of 
+    each shared probe mode.
+    """
+
+    median_filter_abs_probe_px: typing.Tuple[float, float] = ( 1.0, 1.0 )
+    """ A 2-element tuple with the median filter pixel widths in ( rows, cols )
+    """
+
+    median_filter_abs_probe_period: int = 1
+    """ How often (wrt update epochs) we want to apply median filtering to the 
+    absolute value of each shared probe mode.
+    """
+
     probe_update_sum: typing.Union[npt.NDArray, None] = dataclasses.field(
         init=False,
         default_factory=lambda: None,
@@ -194,6 +208,9 @@ class ProbeOptions:
             probe_support=self.probe_support,
             probe_support_degree=self.probe_support_degree,
             probe_support_radius=self.probe_support_radius,
+            median_filter_abs_probe        = self.median_filter_abs_probe, 
+            median_filter_abs_probe_px     = self.median_filter_abs_probe_px,
+            median_filter_abs_probe_period = self.median_filter_abs_probe_period,
         )
         return options
         # Momentum reset to zero when grid scale changes
@@ -870,6 +887,16 @@ def constrain_center_peak(probe):
     probe = stack.reshape(probe.shape)
     return probe
 
+def apply_median_filter_abs_probe( probe, med_filt_px ):
+    """ ABCDEF """
+
+    abs_probe = cp.abs( probe[ 0, 0, ... ] )
+
+    abs_probe = cupyx.scipy.ndimage.median_filter( input = abs_probe, size = ( 1.0, *med_filt_px ), mode = 'constant' )
+    
+    probe[ 0, 0, ... ] = abs_probe * cp.exp( 1j * cp.angle( probe[ 0, 0, ... ] )) 
+
+    return probe
 
 def constrain_probe_sparsity(probe, f):
     """Constrain the probe intensity so at least `f` fraction elements are zero."""

--- a/src/tike/ptycho/probe.py
+++ b/src/tike/ptycho/probe.py
@@ -888,7 +888,22 @@ def constrain_center_peak(probe):
     return probe
 
 def apply_median_filter_abs_probe( probe, med_filt_px ):
-    """ ABCDEF """
+    
+    """Apply a median filter to each of the shared probe modes.
+
+    This is meant as a "quick fix" to the probe "hot spots" 
+    numerical artifacts that arise due to the sample * probe
+    scaling ambiguity we have in phase retrieval under the 
+    projection approximation.
+
+    Parameters
+    ----------
+    probe : ( 1, 1, SHARED, WIDE, HIGH) complex64
+        The shared probes amongst all positions.
+    med_filt_px : typing.Tuple[float, float]
+        A two element array like (tuple or list) with 
+        the median filter pixel widths 
+    """
 
     abs_probe = cp.abs( probe[ 0, 0, ... ] )
 

--- a/src/tike/ptycho/probe.py
+++ b/src/tike/ptycho/probe.py
@@ -144,13 +144,7 @@ class ProbeOptions:
     """
 
     median_filter_abs_probe_px: typing.Tuple[float, float] = ( 1.0, 1.0 )
-    """A 2-element tuple with the median filter pixel widths along each dimension.
-    """
-
-    median_filter_abs_probe_period: int = 1
-    """How often (wrt update epochs) we want to apply median filtering to the 
-    absolute value of each shared probe mode.
-    """
+    """A 2-element tuple with the median filter pixel widths along each dimension."""
 
     probe_update_sum: typing.Union[npt.NDArray, None] = dataclasses.field(
         init=False,
@@ -208,9 +202,8 @@ class ProbeOptions:
             probe_support=self.probe_support,
             probe_support_degree=self.probe_support_degree,
             probe_support_radius=self.probe_support_radius,
-            median_filter_abs_probe        = self.median_filter_abs_probe, 
-            median_filter_abs_probe_px     = self.median_filter_abs_probe_px,
-            median_filter_abs_probe_period = self.median_filter_abs_probe_period,
+            median_filter_abs_probe=self.median_filter_abs_probe, 
+            median_filter_abs_probe_px=self.median_filter_abs_probe_px,
         )
         return options
         # Momentum reset to zero when grid scale changes

--- a/src/tike/ptycho/probe.py
+++ b/src/tike/ptycho/probe.py
@@ -139,16 +139,16 @@ class ProbeOptions:
     """
 
     median_filter_abs_probe: bool = False
-    """ Binary switch on whether to apply a median filter to absolute value of 
+    """Binary switch on whether to apply a median filter to absolute value of 
     each shared probe mode.
     """
 
     median_filter_abs_probe_px: typing.Tuple[float, float] = ( 1.0, 1.0 )
-    """ A 2-element tuple with the median filter pixel widths in ( rows, cols )
+    """A 2-element tuple with the median filter pixel widths along each dimension.
     """
 
     median_filter_abs_probe_period: int = 1
-    """ How often (wrt update epochs) we want to apply median filtering to the 
+    """How often (wrt update epochs) we want to apply median filtering to the 
     absolute value of each shared probe mode.
     """
 

--- a/src/tike/ptycho/ptycho.py
+++ b/src/tike/ptycho/ptycho.py
@@ -440,12 +440,11 @@ class Reconstruction():
                 if self.parameters.probe_options.recover_probe:
 
                     if self.parameters.probe_options.median_filter_abs_probe:
-                        if (( total_epochs % self.parameters.probe_options.median_filter_abs_probe_period ) == 0 ):
-                            self.parameters.probe = self.comm.pool.map(
-                                apply_median_filter_abs_probe,
-                                self.parameters.probe,
-                                med_filt_px = self.parameters.probe_options.median_filter_abs_probe_px
-                            )
+                        self.parameters.probe = self.comm.pool.map(
+                            apply_median_filter_abs_probe,
+                            self.parameters.probe,
+                            med_filt_px = self.parameters.probe_options.median_filter_abs_probe_px
+                        )
 
                     if self.parameters.probe_options.force_centered_intensity:
                         self.parameters.probe = self.comm.pool.map(

--- a/src/tike/ptycho/ptycho.py
+++ b/src/tike/ptycho/ptycho.py
@@ -82,6 +82,7 @@ from .probe import (
     constrain_center_peak,
     constrain_probe_sparsity,
     get_varying_probe,
+    apply_median_filter_abs_probe,
 )
 
 logger = logging.getLogger(__name__)
@@ -437,6 +438,14 @@ class Reconstruction():
 
             if self.parameters.probe_options is not None:
                 if self.parameters.probe_options.recover_probe:
+
+                    if self.parameters.probe_options.median_filter_abs_probe:
+                        if (( total_epochs % self.parameters.probe_options.median_filter_abs_probe_period ) == 0 ):
+                            self.parameters.probe = self.comm.pool.map(
+                                apply_median_filter_abs_probe,
+                                self.parameters.probe,
+                                med_filt_px = self.parameters.probe_options.median_filter_abs_probe_px
+                            )
 
                     if self.parameters.probe_options.force_centered_intensity:
                         self.parameters.probe = self.comm.pool.map(


### PR DESCRIPTION
This doesn't fix the underlying cause of these hot spots but this should cure the symptoms of the underlying disease for the time being

<!--Thank you for opening a pull request!

We appreciate that you care about this project enough to fix it, and we welcome contributions. We will make every effort to review your pull request in a timely manner. Please help us by following the instructions below.
-->

## Purpose
Sometimes we see these strange "hot spots" in the shared probe modes; we are still unsure of the underlying cause of these hot spots but use of a median filter seems to be effective of removing them when do occur. 

## Approach
I introduce a function that simply takes the absolute value of the shared probe modes, and applies a median filter to each mode. The width of the median window is specified in the .toml file; alternatively we default to NOT using any median filtering.

## Pre-Merge Checklists

### Submitter
- [ ] Write a helpfully descriptive pull request title.
- [ ] Organize changes into logically grouped commits with descriptive commit messages.
- [ ] Document all new functions.
- [ ] Click 'details' on the readthedocs check to view the updated docs.
- [ ] Write tests for new functions or explain why they are not needed.
- [ ] Address any complaints from pep8speaks.

### Reviewer
- [x] Actually read all of the code.
- [ ] Run the new code yourself; the included tests should make this easy.
- [ ] Write a summary of the changes as you understand them.
- [ ] Thank the submitter.
