### PR TITLE
NEW: Implement multislice propagation operator with correct adjoint

### DIFF
--- a/src/tike/operators/cupy/convolution.py
+++ b/src/tike/operators/cupy/convolution.py
@@ -102,9 +102,9 @@ class Convolution(Operator):
 
     def adj(self, nearplane, scan, probe, psi=None, overwrite=False):
         """Combine probe shaped patches into a psi shaped grid by addition."""
-        assert probe.shape[:-4] == scan.shape[:-2]
+        assert probe.shape[:-4] == scan.shape[:-2], (probe.shape, scan.shape)
         assert probe.shape[-4] == 1 or probe.shape[-4] == scan.shape[-2]
-        assert nearplane.shape[:-3] == scan.shape[:-1]
+        assert nearplane.shape[:-3] == scan.shape[:-1], (nearplane.shape, scan.shape)
         if not overwrite:
             nearplane = nearplane.copy()
         nearplane[..., self.pad:self.end, self.pad:self.end] *= probe.conj()

--- a/src/tike/operators/cupy/multislice.py
+++ b/src/tike/operators/cupy/multislice.py
@@ -6,22 +6,24 @@ __copyright__ = "Copyright (c) 2024, UChicago Argonne, LLC."
 import typing
 import numpy.typing as npt
 import numpy as np
-import cupy as cp
 
 from .operator import Operator
 
+from .fresnelspectprop import FresnelSpectProp
 from .propagation import Propagation, ZeroPropagation
 from .convolution import Convolution
 
 
 class Multislice(Operator):
+    """Multiple slice wavefield propgation"""
+
     def __init__(
         self,
         detector_shape: int,
         probe_shape: int,
         nz: int,
         n: int,
-        propagation: typing.Type[Propagation] = Propagation,
+        propagation: typing.Type[Propagation] = FresnelSpectProp,
         diffraction: typing.Type[Convolution] = Convolution,
         norm: str = "ortho",
         nslices: int = 1,
@@ -62,7 +64,7 @@ class Multislice(Operator):
         psi: npt.NDArray[np.csingle],
         **kwargs,
     ) -> npt.NDArray[np.csingle]:
-        """Please see help(SingleSlice) for more info."""
+        """Please see help(Multislice) for more info."""
         assert psi.shape[0] == self.nslices and psi.ndim == 3
         exitwave = self.diffraction.fwd(
             psi=psi[0],
@@ -86,7 +88,7 @@ class Multislice(Operator):
         overwrite: bool = False,
         **kwargs,
     ) -> npt.NDArray[np.csingle]:
-        """Please see help(SingleSlice) for more info."""
+        """Please see help(Multislice) for more info."""
         psi_adj = self.xp.zeros_like(psi)
         probes = [
             None,

--- a/src/tike/operators/cupy/multislice.py
+++ b/src/tike/operators/cupy/multislice.py
@@ -124,7 +124,7 @@ class Multislice(Operator):
                 scan=scan,
                 psi=psi[s],
             )
-        # FIXME: Why is division by nslices needed here?
+        # FIXME: Why does correct adjoint require division by nslices?
         return psi_adj / self.nslices, probe_adj
 
     @property

--- a/src/tike/ptycho/solvers/dm.py
+++ b/src/tike/ptycho/solvers/dm.py
@@ -215,19 +215,27 @@ def _get_nearplane_gradients(
         nearplane = op.propagation.adj(farplane, overwrite=True)[..., pad:end,
                                                                  pad:end]
 
-        grad_psi, grad_probe = op.diffraction.adj(
-            nearplane=nearplane[:, 0],
-            probe=varying_probe[:, 0],
-            scan=scan[lo:hi],
-            psi=psi,
-        )
-        grad_probe = cp.sum(
-            grad_probe[:, None],
-            axis=-5,
-            keepdims=True,
-        )
-        psi_update_numerator += grad_psi
-        probe_update_numerator += grad_probe
+        if object_options:
+            grad_psi = (cp.conj(varying_probe) * nearplane).reshape(
+                (hi - lo) * probe.shape[-3], *probe.shape[-2:])
+            psi_update_numerator[0] = op.diffraction.patch.adj(
+                patches=grad_psi,
+                images=psi_update_numerator[0],
+                positions=scan[lo:hi],
+                nrepeat=probe.shape[-3],
+            )
+
+        if probe_options:
+            patches = op.diffraction.patch.fwd(
+                patches=cp.zeros_like(nearplane[..., 0, 0, :, :]),
+                images=psi[0],
+                positions=scan[lo:hi],
+            )[..., None, None, :, :]
+            probe_update_numerator += cp.sum(
+                cp.conj(patches) * nearplane,
+                axis=-5,
+                keepdims=True,
+            )
 
     tike.communicators.stream.stream_and_modify2(
         f=keep_some_args_constant,

--- a/tests/operators/test_multislice.py
+++ b/tests/operators/test_multislice.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import time
 import unittest
 
 import numpy as np
@@ -9,15 +8,15 @@ from tike.operators import Multislice, SingleSlice
 import tike.precision
 import tike.linalg
 
-from .util import random_complex, OperatorTests
+from .util import random_complex
 
 __author__ = "Daniel Ching"
 __copyright__ = "Copyright (c) 2020, UChicago Argonne, LLC."
-__docformat__ = 'restructuredtext en'
+__docformat__ = "restructuredtext en"
 
 
 class TestMultiSlice(unittest.TestCase):
-    """Test the ptychography operator."""
+    """Test the MultiSlice operator."""
 
     def setUp(self, depth=7, pw=15, nscan=27):
         """Load a dataset for reconstruction."""
@@ -30,8 +29,9 @@ class TestMultiSlice(unittest.TestCase):
         print(Multislice)
 
         np.random.seed(0)
-        scan = np.random.rand(*self.scan_shape).astype(
-            tike.precision.floating) * (127 - 16)
+        scan = np.random.rand(*self.scan_shape).astype(tike.precision.floating) * (
+            127 - 16
+        )
         probe = random_complex(*self.probe_shape)
         original = random_complex(*self.original_shape)
         farplane = random_complex(*self.probe_shape[:-2], *self.detector_shape)
@@ -48,40 +48,40 @@ class TestMultiSlice(unittest.TestCase):
         self.xp = self.operator.xp
 
         self.mkwargs = {
-            'probe': self.xp.asarray(probe),
-            'psi': self.xp.asarray(original),
-            'scan': self.xp.asarray(scan),
+            "probe": self.xp.asarray(probe),
+            "psi": self.xp.asarray(original),
+            "scan": self.xp.asarray(scan),
         }
         self.dkwargs = {
-            'nearplane': self.xp.asarray(farplane),
+            "nearplane": self.xp.asarray(farplane),
         }
 
     def test_adjoint(self):
         """Check that the adjoint operator is correct."""
         d = self.operator.fwd(**self.mkwargs)
-        assert d.shape == self.dkwargs['nearplane'].shape
+        assert d.shape == self.dkwargs["nearplane"].shape
         m0, m1 = self.operator.adj(**self.dkwargs, **self.mkwargs)
-        assert m0.shape == self.mkwargs['psi'].shape
-        assert m1.shape == self.mkwargs['probe'].shape
-        a = tike.linalg.inner(d, self.dkwargs['nearplane'])
-        b = tike.linalg.inner(self.mkwargs['psi'], m0)
-        c = tike.linalg.inner(self.mkwargs['probe'], m1)
+        assert m0.shape == self.mkwargs["psi"].shape
+        assert m1.shape == self.mkwargs["probe"].shape
+        a = tike.linalg.inner(d, self.dkwargs["nearplane"])
+        b = tike.linalg.inner(self.mkwargs["psi"], m0)
+        c = tike.linalg.inner(self.mkwargs["probe"], m1)
         print()
-        print('<Fm,    d> = {:.5g}{:+.5g}j'.format(a.real.item(), a.imag.item()))
-        print('< m0, F*d> = {:.5g}{:+.5g}j'.format(b.real.item(), b.imag.item()))
-        print('< m1, F*d> = {:.5g}{:+.5g}j'.format(c.real.item(), c.imag.item()))
+        print("<Fm,    d> = {:.5g}{:+.5g}j".format(a.real.item(), a.imag.item()))
+        print("< m0, F*d> = {:.5g}{:+.5g}j".format(b.real.item(), b.imag.item()))
+        print("< m1, F*d> = {:.5g}{:+.5g}j".format(c.real.item(), c.imag.item()))
         self.xp.testing.assert_allclose(a.real, b.real, rtol=1e-3, atol=0)
         self.xp.testing.assert_allclose(a.imag, b.imag, rtol=1e-3, atol=0)
         self.xp.testing.assert_allclose(a.real, c.real, rtol=1e-3, atol=0)
         self.xp.testing.assert_allclose(a.imag, c.imag, rtol=1e-3, atol=0)
 
-    @unittest.skip('FIXME: This operator is not scaled.')
+    @unittest.skip("FIXME: This operator is not scaled.")
     def test_scaled(self):
         pass
 
 
 class TestSingleSlice(TestMultiSlice):
-    """Test the ptychography operator."""
+    """Test the SingleSlice operator."""
 
     def setUp(self, depth=1, pw=15, nscan=27):
         """Load a dataset for reconstruction."""
@@ -91,16 +91,17 @@ class TestSingleSlice(TestMultiSlice):
         self.detector_shape = (pw, pw)
         self.original_shape = (depth, 128, 128)
         self.scan_shape = (nscan, 2)
-        print(Multislice)
+        print(SingleSlice)
 
         np.random.seed(0)
-        scan = np.random.rand(*self.scan_shape).astype(
-            tike.precision.floating) * (127 - 16)
+        scan = np.random.rand(*self.scan_shape).astype(tike.precision.floating) * (
+            127 - 16
+        )
         probe = random_complex(*self.probe_shape)
         original = random_complex(*self.original_shape)
         farplane = random_complex(*self.probe_shape[:-2], *self.detector_shape)
 
-        self.operator = Multislice(
+        self.operator = SingleSlice(
             nscan=self.scan_shape[-2],
             probe_shape=self.probe_shape[-1],
             detector_shape=self.detector_shape[-1],
@@ -112,14 +113,14 @@ class TestSingleSlice(TestMultiSlice):
         self.xp = self.operator.xp
 
         self.mkwargs = {
-            'probe': self.xp.asarray(probe),
-            'psi': self.xp.asarray(original),
-            'scan': self.xp.asarray(scan),
+            "probe": self.xp.asarray(probe),
+            "psi": self.xp.asarray(original),
+            "scan": self.xp.asarray(scan),
         }
         self.dkwargs = {
-            'nearplane': self.xp.asarray(farplane),
+            "nearplane": self.xp.asarray(farplane),
         }
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/operators/test_multislice.py
+++ b/tests/operators/test_multislice.py
@@ -5,8 +5,7 @@ import time
 import unittest
 
 import numpy as np
-from tike.operators import Multislice
-from tike.operators.cupy.multislice import SingleSlice
+from tike.operators import Multislice, SingleSlice
 import tike.precision
 import tike.linalg
 
@@ -17,7 +16,7 @@ __copyright__ = "Copyright (c) 2020, UChicago Argonne, LLC."
 __docformat__ = 'restructuredtext en'
 
 
-class TestMultislice(unittest.TestCase):
+class TestMultiSlice(unittest.TestCase):
     """Test the ptychography operator."""
 
     def setUp(self, depth=7, pw=15, nscan=27):
@@ -55,16 +54,13 @@ class TestMultislice(unittest.TestCase):
         }
         self.dkwargs = {
             'nearplane': self.xp.asarray(farplane),
-            'probe': self.xp.asarray(probe),
-            'psi': self.xp.asarray(original),
-            'scan': self.xp.asarray(scan),
         }
 
     def test_adjoint(self):
         """Check that the adjoint operator is correct."""
         d = self.operator.fwd(**self.mkwargs)
         assert d.shape == self.dkwargs['nearplane'].shape
-        m0, m1 = self.operator.adj(**self.dkwargs)
+        m0, m1 = self.operator.adj(**self.dkwargs, **self.mkwargs)
         assert m0.shape == self.mkwargs['psi'].shape
         assert m1.shape == self.mkwargs['probe'].shape
         a = tike.linalg.inner(d, self.dkwargs['nearplane'])
@@ -74,15 +70,17 @@ class TestMultislice(unittest.TestCase):
         print('<Fm,    d> = {:.5g}{:+.5g}j'.format(a.real.item(), a.imag.item()))
         print('< m0, F*d> = {:.5g}{:+.5g}j'.format(b.real.item(), b.imag.item()))
         print('< m1, F*d> = {:.5g}{:+.5g}j'.format(c.real.item(), c.imag.item()))
-        # self.xp.testing.assert_allclose(a.real, b.real, rtol=1e-3, atol=0)
-        # self.xp.testing.assert_allclose(a.imag, b.imag, rtol=1e-3, atol=0)
+        self.xp.testing.assert_allclose(a.real, b.real, rtol=1e-3, atol=0)
+        self.xp.testing.assert_allclose(a.imag, b.imag, rtol=1e-3, atol=0)
+        self.xp.testing.assert_allclose(a.real, c.real, rtol=1e-3, atol=0)
+        self.xp.testing.assert_allclose(a.imag, c.imag, rtol=1e-3, atol=0)
 
     @unittest.skip('FIXME: This operator is not scaled.')
     def test_scaled(self):
         pass
 
 
-class TestSingleslice(unittest.TestCase):
+class TestSingleSlice(TestMultiSlice):
     """Test the ptychography operator."""
 
     def setUp(self, depth=1, pw=15, nscan=27):
@@ -102,7 +100,7 @@ class TestSingleslice(unittest.TestCase):
         original = random_complex(*self.original_shape)
         farplane = random_complex(*self.probe_shape[:-2], *self.detector_shape)
 
-        self.operator = SingleSlice(
+        self.operator = Multislice(
             nscan=self.scan_shape[-2],
             probe_shape=self.probe_shape[-1],
             detector_shape=self.detector_shape[-1],
@@ -119,29 +117,8 @@ class TestSingleslice(unittest.TestCase):
             'scan': self.xp.asarray(scan),
         }
         self.dkwargs = {
-            'nearplane': self.xp.asarray(farplane)
+            'nearplane': self.xp.asarray(farplane),
         }
-
-    def test_adjoint(self):
-        """Check that the adjoint operator is correct."""
-        d = self.operator.fwd(**self.mkwargs)
-        assert d.shape == self.dkwargs['nearplane'].shape
-        m0, m1 = self.operator.adj(**self.mkwargs, **self.dkwargs)
-        assert m0.shape == self.mkwargs['psi'].shape
-        assert m1.shape == self.mkwargs['probe'].shape
-        a = tike.linalg.inner(d, self.dkwargs['nearplane'])
-        b = tike.linalg.inner(self.mkwargs['psi'], m0)
-        c = tike.linalg.inner(self.mkwargs['probe'], m1)
-        print()
-        print('<Fm,  m0> = {:.5g}{:+.5g}j'.format(a.real.item(), a.imag.item()))
-        print('<Fm,  m1> = {:.5g}{:+.5g}j'.format(c.real.item(), c.imag.item()))
-        print('< d, F*d> = {:.5g}{:+.5g}j'.format(b.real.item(), b.imag.item()))
-        self.xp.testing.assert_allclose(a.real, b.real, rtol=1e-3, atol=0)
-        self.xp.testing.assert_allclose(a.imag, b.imag, rtol=1e-3, atol=0)
-
-    @unittest.skip('FIXME: This operator is not scaled.')
-    def test_scaled(self):
-        pass
 
 
 if __name__ == '__main__':

--- a/tests/operators/test_multislice.py
+++ b/tests/operators/test_multislice.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import time
+import unittest
+
+import numpy as np
+from tike.operators import Multislice
+from tike.operators.cupy.multislice import SingleSlice
+import tike.precision
+import tike.linalg
+
+from .util import random_complex, OperatorTests
+
+__author__ = "Daniel Ching"
+__copyright__ = "Copyright (c) 2020, UChicago Argonne, LLC."
+__docformat__ = 'restructuredtext en'
+
+
+class TestMultislice(unittest.TestCase):
+    """Test the ptychography operator."""
+
+    def setUp(self, depth=7, pw=15, nscan=27):
+        """Load a dataset for reconstruction."""
+        self.nscan = nscan
+        self.nprobe = 3
+        self.probe_shape = (nscan, self.nprobe, pw, pw)
+        self.detector_shape = (pw, pw)
+        self.original_shape = (depth, 128, 128)
+        self.scan_shape = (nscan, 2)
+        print(Multislice)
+
+        np.random.seed(0)
+        scan = np.random.rand(*self.scan_shape).astype(
+            tike.precision.floating) * (127 - 16)
+        probe = random_complex(*self.probe_shape)
+        original = random_complex(*self.original_shape)
+        farplane = random_complex(*self.probe_shape[:-2], *self.detector_shape)
+
+        self.operator = Multislice(
+            nscan=self.scan_shape[-2],
+            probe_shape=self.probe_shape[-1],
+            detector_shape=self.detector_shape[-1],
+            nz=self.original_shape[-2],
+            n=self.original_shape[-1],
+            nslices=depth,
+        )
+        self.operator.__enter__()
+        self.xp = self.operator.xp
+
+        self.mkwargs = {
+            'probe': self.xp.asarray(probe),
+            'psi': self.xp.asarray(original),
+            'scan': self.xp.asarray(scan),
+        }
+        self.dkwargs = {
+            'nearplane': self.xp.asarray(farplane),
+            'probe': self.xp.asarray(probe),
+            'psi': self.xp.asarray(original),
+            'scan': self.xp.asarray(scan),
+        }
+
+    def test_adjoint(self):
+        """Check that the adjoint operator is correct."""
+        d = self.operator.fwd(**self.mkwargs)
+        assert d.shape == self.dkwargs['nearplane'].shape
+        m0, m1 = self.operator.adj(**self.dkwargs)
+        assert m0.shape == self.mkwargs['psi'].shape
+        assert m1.shape == self.mkwargs['probe'].shape
+        a = tike.linalg.inner(d, self.dkwargs['nearplane'])
+        b = tike.linalg.inner(self.mkwargs['psi'], m0)
+        c = tike.linalg.inner(self.mkwargs['probe'], m1)
+        print()
+        print('<Fm,    d> = {:.5g}{:+.5g}j'.format(a.real.item(), a.imag.item()))
+        print('< m0, F*d> = {:.5g}{:+.5g}j'.format(b.real.item(), b.imag.item()))
+        print('< m1, F*d> = {:.5g}{:+.5g}j'.format(c.real.item(), c.imag.item()))
+        # self.xp.testing.assert_allclose(a.real, b.real, rtol=1e-3, atol=0)
+        # self.xp.testing.assert_allclose(a.imag, b.imag, rtol=1e-3, atol=0)
+
+    @unittest.skip('FIXME: This operator is not scaled.')
+    def test_scaled(self):
+        pass
+
+
+class TestSingleslice(unittest.TestCase):
+    """Test the ptychography operator."""
+
+    def setUp(self, depth=1, pw=15, nscan=27):
+        """Load a dataset for reconstruction."""
+        self.nscan = nscan
+        self.nprobe = 3
+        self.probe_shape = (nscan, self.nprobe, pw, pw)
+        self.detector_shape = (pw, pw)
+        self.original_shape = (depth, 128, 128)
+        self.scan_shape = (nscan, 2)
+        print(Multislice)
+
+        np.random.seed(0)
+        scan = np.random.rand(*self.scan_shape).astype(
+            tike.precision.floating) * (127 - 16)
+        probe = random_complex(*self.probe_shape)
+        original = random_complex(*self.original_shape)
+        farplane = random_complex(*self.probe_shape[:-2], *self.detector_shape)
+
+        self.operator = SingleSlice(
+            nscan=self.scan_shape[-2],
+            probe_shape=self.probe_shape[-1],
+            detector_shape=self.detector_shape[-1],
+            nz=self.original_shape[-2],
+            n=self.original_shape[-1],
+            nslices=depth,
+        )
+        self.operator.__enter__()
+        self.xp = self.operator.xp
+
+        self.mkwargs = {
+            'probe': self.xp.asarray(probe),
+            'psi': self.xp.asarray(original),
+            'scan': self.xp.asarray(scan),
+        }
+        self.dkwargs = {
+            'nearplane': self.xp.asarray(farplane)
+        }
+
+    def test_adjoint(self):
+        """Check that the adjoint operator is correct."""
+        d = self.operator.fwd(**self.mkwargs)
+        assert d.shape == self.dkwargs['nearplane'].shape
+        m0, m1 = self.operator.adj(**self.mkwargs, **self.dkwargs)
+        assert m0.shape == self.mkwargs['psi'].shape
+        assert m1.shape == self.mkwargs['probe'].shape
+        a = tike.linalg.inner(d, self.dkwargs['nearplane'])
+        b = tike.linalg.inner(self.mkwargs['psi'], m0)
+        c = tike.linalg.inner(self.mkwargs['probe'], m1)
+        print()
+        print('<Fm,  m0> = {:.5g}{:+.5g}j'.format(a.real.item(), a.imag.item()))
+        print('<Fm,  m1> = {:.5g}{:+.5g}j'.format(c.real.item(), c.imag.item()))
+        print('< d, F*d> = {:.5g}{:+.5g}j'.format(b.real.item(), b.imag.item()))
+        self.xp.testing.assert_allclose(a.real, b.real, rtol=1e-3, atol=0)
+        self.xp.testing.assert_allclose(a.imag, b.imag, rtol=1e-3, atol=0)
+
+    @unittest.skip('FIXME: This operator is not scaled.')
+    def test_scaled(self):
+        pass
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/operators/test_ptycho.py
+++ b/tests/operators/test_ptycho.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import time
 import unittest
 
 import numpy as np
@@ -9,11 +8,11 @@ from tike.operators import Ptycho
 import tike.precision
 import tike.linalg
 
-from .util import random_complex, OperatorTests
+from .util import random_complex
 
 __author__ = "Daniel Ching"
 __copyright__ = "Copyright (c) 2020, UChicago Argonne, LLC."
-__docformat__ = 'restructuredtext en'
+__docformat__ = "restructuredtext en"
 
 
 class TestPtycho(unittest.TestCase):
@@ -30,8 +29,9 @@ class TestPtycho(unittest.TestCase):
         print(Ptycho)
 
         np.random.seed(0)
-        scan = np.random.rand(*self.scan_shape).astype(
-            tike.precision.floating) * (127 - 16)
+        scan = np.random.rand(*self.scan_shape).astype(tike.precision.floating) * (
+            127 - 16
+        )
         probe = random_complex(*self.probe_shape)
         original = random_complex(*self.original_shape)
         farplane = random_complex(*self.probe_shape[:-2], *self.detector_shape)
@@ -74,10 +74,10 @@ class TestPtycho(unittest.TestCase):
         self.xp.testing.assert_allclose(a.real, c.real, rtol=1e-3, atol=0)
         self.xp.testing.assert_allclose(a.imag, c.imag, rtol=1e-3, atol=0)
 
-    @unittest.skip('FIXME: This operator is not scaled.')
+    @unittest.skip("FIXME: This operator is not scaled.")
     def test_scaled(self):
         pass
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!--Thank you for opening a pull request!

We appreciate that you care about this project enough to fix it, and we welcome contributions. We will make every effort to review your pull request in a timely manner. Please help us by following the instructions below.
-->

## Purpose
<!--Describe the problem or feature.

Only address one feature per pull request. If the scope of a single pull request is small (less than 400 lines of code), reviewers can understand it more quickly.

Link to any existing Issues. Use the `Closes` keyword if this Pull closes any Issues.
-->
Implement a correct adjoint operation for multi-slice propagation.

## Approach
<!--Describe how your changes address the problem.

Provide a brief summary of your algorithm(s) here.
-->

- Replace placeholder class with correctly implemented MultiSlice operator
  - Adjoint function is double adjoint instead of separate for probe and object
- Remove *unused* specialized adjoint methods from the Ptycho operator because these methods would require reimplementation to work with the new MultiSlice operator
- Implement new operator tests for the new MultiSlice and Ptycho Operator APIs; these tests prove that the adjoint operations are correct

## Pre-Merge Checklists

### Submitter
- [ ] Write a helpfully descriptive pull request title.
- [ ] Organize changes into logically grouped commits with descriptive commit messages.
- [ ] Document all new functions.
- [ ] Click 'details' on the readthedocs check to view the updated docs.
- [ ] Write tests for new functions or explain why they are not needed.
- [ ] Address any complaints from pep8speaks.

### Reviewer
- [ ] Actually read all of the code.
- [ ] Run the new code yourself; the included tests should make this easy.
- [ ] Write a summary of the changes as you understand them.
- [ ] Thank the submitter.
