### PR TITLE
probe options and object options now include relevant Fresnel spectrum propagation multislice parameters and are used in the fwd and adj operators

### DIFF
--- a/src/tike/operators/cupy/multislice.py
+++ b/src/tike/operators/cupy/multislice.py
@@ -21,8 +21,11 @@ class Multislice(Operator):
         self,
         detector_shape: int,
         probe_shape: int,
+        probe_wavelength: float,
+        probe_FOV_lengths: typing.Tuple[float, float],
         nz: int,
         n: int,
+        multislice_propagation_distance: float,
         propagation: typing.Type[Propagation] = FresnelSpectProp,
         diffraction: typing.Type[Convolution] = Convolution,
         norm: str = "ortho",
@@ -37,7 +40,11 @@ class Multislice(Operator):
             **kwargs,
         )
         self.propagation = propagation(
-            detector_shape=detector_shape,
+            norm = norm,
+            probe_shape=probe_shape,
+            wavelength=probe_wavelength,
+            probe_FOV=probe_FOV_lengths,
+            distance=multislice_propagation_distance,
             **kwargs,
         )
 
@@ -46,7 +53,10 @@ class Multislice(Operator):
         self.detector_shape = detector_shape
         self.nz = nz
         self.n = n
-
+        self.probe_wavelength = probe_wavelength
+        self.probe_FOV_lengths = probe_FOV_lengths
+        self.multislice_propagation_distance = multislice_propagation_distance
+        
     def __enter__(self):
         self.propagation.__enter__()
         self.diffraction.__enter__()

--- a/src/tike/operators/cupy/ptycho.py
+++ b/src/tike/operators/cupy/ptycho.py
@@ -67,8 +67,11 @@ class Ptycho(Operator):
         self,
         detector_shape: int,
         probe_shape: int,
+        probe_wavelength: float,
+        probe_FOV_lengths: typing.Tuple[float, float],
         nz: int,
         n: int,
+        multislice_propagation_distance: float,
         propagation: typing.Type[Propagation] = Propagation,
         diffraction: typing.Type[Multislice] = Multislice,
         norm: str = 'ortho',
@@ -82,9 +85,12 @@ class Ptycho(Operator):
         )
         self.diffraction = diffraction(
             probe_shape=probe_shape,
+            probe_wavelength=probe_wavelength,
+            probe_FOV_lengths=probe_FOV_lengths,
             detector_shape=detector_shape,
             nz=nz,
             n=n,
+            multislice_propagation_distance=multislice_propagation_distance,
             **kwargs,
         )
         # TODO: Replace these with @property functions
@@ -92,7 +98,10 @@ class Ptycho(Operator):
         self.detector_shape = detector_shape
         self.nz = nz
         self.n = n
-
+        self.probe_wavelength = probe_wavelength
+        self.probe_FOV_lengths = probe_FOV_lengths
+        self.multislice_propagation_distance = multislice_propagation_distance
+        
     def __enter__(self):
         self.propagation.__enter__()
         self.diffraction.__enter__()

--- a/src/tike/ptycho/object.py
+++ b/src/tike/ptycho/object.py
@@ -73,7 +73,13 @@ class ObjectOptions:
 
     clip_magnitude: bool = False
     """Whether to force the object magnitude to remain <= 1."""
-
+    
+    multislice_propagation_distance: float = 1.0e-9      
+    """ If we're doing multislice ptychography, then this will be 
+    the slice to slice distance along the probing wavefield propagation
+    direction. Units are meters.
+    """
+    
     def copy_to_device(self) -> ObjectOptions:
         """Copy to the current GPU memory."""
         options = ObjectOptions(
@@ -84,6 +90,7 @@ class ObjectOptions:
             vdecay=self.vdecay,
             mdecay=self.mdecay,
             clip_magnitude=self.clip_magnitude,
+            multislice_propagation_distance=self.multislice_propagation_distance,
         )
         options.update_mnorm = copy.copy(self.update_mnorm)
         if self.v is not None:
@@ -117,6 +124,7 @@ class ObjectOptions:
             vdecay=self.vdecay,
             mdecay=self.mdecay,
             clip_magnitude=self.clip_magnitude,
+            multislice_propagation_distance=self.multislice_propagation_distance,
         )
         options.update_mnorm = copy.copy(self.update_mnorm)
         if self.v is not None:
@@ -137,6 +145,7 @@ class ObjectOptions:
             vdecay=self.vdecay,
             mdecay=self.mdecay,
             clip_magnitude=self.clip_magnitude,
+            multislice_propagation_distance=self.multislice_propagation_distance,
         )
         options.update_mnorm = copy.copy(self.update_mnorm)
         return options
@@ -172,6 +181,7 @@ class ObjectOptions:
             vdecay=x[0].vdecay,
             mdecay=x[0].mdecay,
             clip_magnitude=x[0].clip_magnitude,
+            multislice_propagation_distance=x[0].multislice_propagation_distance,
         )
         options.update_mnorm = copy.copy(x[0].update_mnorm)
         if x[0].v is not None:

--- a/src/tike/ptycho/probe.py
+++ b/src/tike/ptycho/probe.py
@@ -72,6 +72,17 @@ class ProbeOptions:
     it will default to the average of the measurement intensity scaling.
     """
 
+    probe_wavelength: float = np.nan
+    """ The wavelength (meters) of the probing wavefield; 
+    we assume a monochomatic (single wavelength) probe.
+    """
+
+    probe_FOV_lengths: typing.Tuple[float, float] = ( np.nan, np.nan )
+    """ The transverse field of view (FOV) for the probe in
+    units of length (meters). The first element is vertical FOV, 
+    the second element is horizontal FOV.
+    """
+
     force_orthogonality: bool = False
     """Forces probes to be orthogonal each iteration."""
 
@@ -164,6 +175,8 @@ class ProbeOptions:
             update_period=self.update_period,
             init_rescale_from_measurements=self.init_rescale_from_measurements,
             probe_photons=self.probe_photons,
+            probe_wavelength=self.probe_wavelength,
+            probe_FOV_lengths=self.probe_FOV_lengths,
             force_orthogonality=self.force_orthogonality,
             force_centered_intensity=self.force_centered_intensity,
             force_sparsity=self.force_sparsity,
@@ -206,6 +219,8 @@ class ProbeOptions:
             update_period=self.update_period,
             init_rescale_from_measurements=self.init_rescale_from_measurements,
             probe_photons=self.probe_photons,
+            probe_wavelength=self.probe_wavelength,
+            probe_FOV_lengths=self.probe_FOV_lengths,
             force_orthogonality=self.force_orthogonality,
             force_centered_intensity=self.force_centered_intensity,
             force_sparsity=self.force_sparsity,
@@ -235,6 +250,8 @@ class ProbeOptions:
             update_period=self.update_period,
             init_rescale_from_measurements=self.init_rescale_from_measurements,
             probe_photons=self.probe_photons,
+            probe_wavelength=self.probe_wavelength,
+            probe_FOV_lengths=self.probe_FOV_lengths,
             force_orthogonality=self.force_orthogonality,
             force_centered_intensity=self.force_centered_intensity,
             force_sparsity=self.force_sparsity,

--- a/src/tike/ptycho/ptycho.py
+++ b/src/tike/ptycho/ptycho.py
@@ -349,6 +349,9 @@ class Reconstruction():
             nz=parameters.psi.shape[-2],
             n=parameters.psi.shape[-1],
             norm=parameters.exitwave_options.propagation_normalization,
+            probe_wavelength=parameters.probe_options.probe_wavelength,
+            probe_FOV_lengths=parameters.probe_options.probe_FOV_lengths,
+            multislice_propagation_distance=parameters.object_options.multislice_propagation_distance,
         )
         self.comm = tike.communicators.Comm(num_gpu, mpi)
 

--- a/tests/operators/test_multislice.py
+++ b/tests/operators/test_multislice.py
@@ -39,9 +39,12 @@ class TestMultiSlice(unittest.TestCase):
         self.operator = Multislice(
             nscan=self.scan_shape[-2],
             probe_shape=self.probe_shape[-1],
+            probe_wavelength = 1e-10,
+            probe_FOV_lengths = (1e-5, 1e-5),
             detector_shape=self.detector_shape[-1],
             nz=self.original_shape[-2],
             n=self.original_shape[-1],
+            multislice_propagation_distance = 1e-8,
         )
         self.operator.__enter__()
         self.xp = self.operator.xp


### PR DESCRIPTION
<!--Thank you for opening a pull request!

We appreciate that you care about this project enough to fix it, and we welcome contributions. We will make every effort to review your pull request in a timely manner. Please help us by following the instructions below.
-->

## Purpose
Previously the multislice class and resulting forward and adjoint operators didn't use the specified parameters (e.g. probe wavelength, probe field of view (FOV), and multislice propagation distance), and instead always used the defaults.

Now, these parameters are explicitly passed into the multislice class.

Also, I now use the same propagator that fold_slice uses, not the one without phase prefactors and with the square root taylor expansion.

## Approach

The probe wavelength and probe field of view (FOV) are now part of probe_options and multislice propagation distance is part of object options.

These parameters are then used in the multislice class for a composite operator which uses fresnel spectrum propagation of the  type fold_slice uses.

## Pre-Merge Checklists

### Submitter
- [ ] Write a helpfully descriptive pull request title.
- [ ] Organize changes into logically grouped commits with descriptive commit messages.
- [ ] Document all new functions.
- [ ] Click 'details' on the readthedocs check to view the updated docs.
- [ ] Write tests for new functions or explain why they are not needed.
- [ ] Address any complaints from pep8speaks.

### Reviewer
- [ ] Actually read all of the code.
- [ ] Run the new code yourself; the included tests should make this easy.
- [ ] Write a summary of the changes as you understand them.
- [ ] Thank the submitter.
