### PR TITLE
rPIE tweaks, comment out rPIE scan position correction as it's not doing things correctly (I'll fix later).

### DIFF
--- a/src/tike/ptycho/solvers/rpie.py
+++ b/src/tike/ptycho/solvers/rpie.py
@@ -108,7 +108,6 @@ def rpie(
             costs,
             psi_update_numerator,
             probe_update_numerator,
-            multislice_probe_update_numerator,
             position_update_numerator,
             position_update_denominator,
             eigen_weights,
@@ -144,12 +143,8 @@ def rpie(
             ) = _update(
                 psi,
                 probe,
-
-                op,
                 psi_update_numerator,
-                probe_update_numerator,
-                multislice_probe_update_numerator, 
-                
+                probe_update_numerator, 
                 object_options,
                 probe_options,
                 recover_probe,
@@ -160,19 +155,19 @@ def rpie(
 
     algorithm_options.costs.append([float(batch_cost.mean().get())])
 
-    if position_options is not None:
-        (
-            scan,
-            position_options,
-        ) = _update_position(
-            scan,
-            position_options,
-            position_update_numerator,
-            position_update_denominator,
-            max_shift=probe[0].shape[-1] * 0.1,
-            alpha=algorithm_options.alpha,
-            epoch=epoch,
-        )
+    # if position_options is not None:
+    #     (
+    #         scan,
+    #         position_options,
+    #     ) = _update_position(
+    #         scan,
+    #         position_options,
+    #         position_update_numerator,
+    #         position_update_denominator,
+    #         max_shift=probe[0].shape[-1] * 0.1,
+    #         alpha=algorithm_options.alpha,
+    #         epoch=epoch,
+    #     )
 
     if algorithm_options.batch_method == 'compact':
         (
@@ -181,12 +176,8 @@ def rpie(
         ) = _update(
             psi,
             probe,
-
-            op,
             psi_update_numerator,
-            probe_update_numerator,
-            multislice_probe_update_numerator, 
-
+            probe_update_numerator, 
             object_options,
             probe_options,
             recover_probe,
@@ -226,12 +217,8 @@ def _normalize_eigen_weights(eigen_weights):
 def _update(
     psi: npt.NDArray[cp.csingle],
     probe: npt.NDArray[cp.csingle],
-
-    op: tike.operators.Ptycho,  
     psi_update_numerator: npt.NDArray[cp.csingle],          
     probe_update_numerator: npt.NDArray[cp.csingle],
-    multislice_probe_update_numerator: npt.NDArray[cp.csingle],
-
     object_options: ObjectOptions,
     probe_options: ProbeOptions,
     recover_probe: bool,
@@ -249,37 +236,6 @@ def _update(
         )
 
         psi = psi + dpsi / deno
-
-        ''' 
-        import matplotlib.pyplot as plt
-        #import numpy as np
-        from mpl_toolkits.axes_grid1 import make_axes_locatable
-        import matplotlib as mpl
-        # mpl.use('Agg')
-        mpl.use('TKAgg')
-
-        # A = np.abs( psi[ 0, ... ] )
-        A = np.angle( psi[ 0, ... ] )
-        fig, ax1 = plt.subplots( nrows = 1, ncols = 1, )
-        pos1 = ax1.imshow( A.get(), cmap = 'gray', ) 
-        plt.colorbar(pos1)
-        plt.show( block = False )
-    
-        # B = np.abs( psi[ 1, ... ] )
-        B = np.angle( psi[ 1, ... ] )
-        fig, ax2 = plt.subplots( nrows = 1, ncols = 1, )
-        pos2 = ax2.imshow( B.get(), cmap = 'gray', ) 
-        plt.colorbar(pos2)
-        plt.show( block = False )
-
-        # C = np.abs( psi[ 2, ... ] )
-        C = np.angle( psi[ 2, ... ] )
-        fig, ax3 = plt.subplots( nrows = 1, ncols = 1, )
-        pos3 = ax3.imshow( C.get(), cmap = 'gray', ) 
-        plt.colorbar(pos3)
-        plt.show( block = False )
-        '''
-
 
         if object_options.use_adaptive_moment:
             if errors:
@@ -312,7 +268,7 @@ def _update(
 
     if recover_probe:
 
-        dprobe = multislice_probe_update_numerator[ 0, ... ]
+        dprobe = probe_update_numerator[ 0, ... ]
 
         # deno = (
         #     ( 1 - algorithm_options.alpha) * probe_options.preconditioner[ 0, ... ]
@@ -322,52 +278,6 @@ def _update(
         deno = algorithm_options.alpha * probe_options.preconditioner[ 0, ... ].max( axis=(-2, -1), keepdims=True, )
         
         probe = probe + dprobe / deno
-
-
-
-
-        ''' 
-
-        import matplotlib.pyplot as plt
-        #import numpy as np
-        from mpl_toolkits.axes_grid1 import make_axes_locatable
-        import matplotlib as mpl
-        # mpl.use('Agg')
-        mpl.use('TKAgg')
-
-        A = np.abs( probe[ 0, 0, -5, ... ] )
-        fig, ax1 = plt.subplots( nrows = 1, ncols = 1, )
-        pos1 = ax1.imshow( A.get(), cmap = 'gray', ) 
-        plt.colorbar(pos1)
-        plt.show( block = False )
-    
-        B = np.abs( probe[ 0, 0, -4, ... ] )
-        fig, ax2 = plt.subplots( nrows = 1, ncols = 1, )
-        pos2 = ax2.imshow( B.get(), cmap = 'gray', ) 
-        plt.colorbar(pos2)
-        plt.show( block = False )
-
-        C = np.abs( probe[ 0, 0, -3, ... ] )
-        fig, ax3 = plt.subplots( nrows = 1, ncols = 1, )
-        pos3 = ax3.imshow( C.get(), cmap = 'gray', ) 
-        plt.colorbar(pos3)
-        plt.show( block = False )
-
-        D = np.abs( probe[ 0, 0, -2, ... ] )
-        fig, ax3 = plt.subplots( nrows = 1, ncols = 1, )
-        pos3 = ax3.imshow( D.get(), cmap = 'gray', ) 
-        plt.colorbar(pos3)
-        plt.show( block = False )
-
-        E = np.abs( probe[ 0, 0, -1, ... ] )
-        fig, ax3 = plt.subplots( nrows = 1, ncols = 1, )
-        pos3 = ax3.imshow( D.get(), cmap = 'gray', ) 
-        plt.colorbar(pos3)
-        plt.show( block = False )
-
-        '''
-
-
 
         if probe_options.use_adaptive_moment:
             # ptychoshelves only applies momentum to the main probe
@@ -435,9 +345,8 @@ def _get_nearplane_gradients(
 
     psi_update_numerator = cp.zeros_like( psi ) if psi_update_numerator is None else psi_update_numerator
     
-    probe_update_numerator = cp.zeros_like( probe ) if probe_update_numerator is None else probe_update_numerator
-    
-    multislice_probe_update_numerator = cp.zeros( ( psi.shape[0], *probe.shape ), dtype = probe.dtype )
+    #probe_update_numerator = cp.zeros_like( probe ) if probe_update_numerator is None else probe_update_numerator
+    probe_update_numerator = cp.zeros( ( psi.shape[0], *probe.shape ), dtype = probe.dtype )
 
     position_update_numerator = cp.empty_like( scan ) if position_update_numerator is None else position_update_numerator
 
@@ -462,9 +371,7 @@ def _get_nearplane_gradients(
             eigen_weights[lo:hi] if eigen_weights is not None else None,
         )
 
-        #farplane = op.fwd(probe=unique_probe, scan=scan[lo:hi], psi=psi)
-
-        farplane, multislice_probes  = op.fwd_return_intermediate_probes(probe=unique_probe, scan=scan[lo:hi], psi=psi)
+        farplane, multislice_probes = op.fwd_return_intermediate_probes(probe=unique_probe, scan=scan[lo:hi], psi=psi)
 
         intensity = cp.sum(
             cp.square(cp.abs(farplane)),
@@ -536,19 +443,11 @@ def _get_nearplane_gradients(
         diff = op.propagation.adj(farplane, overwrite=True)[..., pad:end, pad:end]
 
         if object_options:
-            for tt in cp.arange( psi.shape[0] - 1, -1, -1 ) :
-            #for tt in range(len(psi) - 1, -1, -1 ) :        
 
-        
-                #grad_psi = (cp.conj(unique_probe) * diff / probe.shape[-3]).reshape( scan[lo:hi].shape[0] * probe.shape[-3], *probe.shape[-2:])
+            #for tt in cp.arange( psi.shape[0] - 1, -1, -1 ) :
+            for tt in range(len(psi) - 1, -1, -1 ) :        
+
                 grad_psi = (cp.conj(multislice_probes[ tt, :, None, ... ]) * diff / probe.shape[-3]).reshape( scan[lo:hi].shape[0] * probe.shape[-3], *probe.shape[-2:] )
-
-                # psi_update_numerator[0] = op.diffraction.patch.adj(
-                #     patches=grad_psi,
-                #     images=psi_update_numerator[0],
-                #     positions=scan[lo:hi],
-                #     nrepeat=probe.shape[-3],
-                # )
 
                 psi_update_numerator[ tt, ... ] = op.diffraction.patch.adj(
                 patches=grad_psi,
@@ -563,7 +462,7 @@ def _get_nearplane_gradients(
                         positions=scan[lo:hi],
                     )[..., None, None, :, :]
 
-                multislice_probe_update_numerator[ tt, ... ] += cp.sum(
+                probe_update_numerator[ tt, ... ] += cp.sum(
                         cp.conj(patches) * diff,
                         axis=-5,
                         keepdims=True,
@@ -606,47 +505,47 @@ def _get_nearplane_gradients(
                     0.1 * (eigen_numerator / eigen_denominator)
                 )  # yapf: disable
 
-        if position_options:
-            grad_x, grad_y = tike.ptycho.position.gaussian_gradient(patches)
+        # if position_options:
+        #     grad_x, grad_y = tike.ptycho.position.gaussian_gradient(patches)
 
-            crop = probe.shape[-1] // 4
+        #     crop = probe.shape[-1] // 4
 
-            position_update_numerator[lo:hi, ..., 0] = cp.sum(
-                cp.real(
-                    cp.conj(
-                        grad_x[..., crop:-crop, crop:-crop]
-                        * unique_probe[..., crop:-crop, crop:-crop]
-                    )
-                    * diff[..., crop:-crop, crop:-crop]
-                ),
-                axis=(-4, -3, -2, -1),
-            )
-            position_update_denominator[lo:hi, ..., 0] = cp.sum(
-                cp.abs(
-                    grad_x[..., crop:-crop, crop:-crop]
-                    * unique_probe[..., crop:-crop, crop:-crop]
-                )
-                ** 2,
-                axis=(-4, -3, -2, -1),
-            )
-            position_update_numerator[lo:hi, ..., 1] = cp.sum(
-                cp.real(
-                    cp.conj(
-                        grad_y[..., crop:-crop, crop:-crop]
-                        * unique_probe[..., crop:-crop, crop:-crop]
-                    )
-                    * diff[..., crop:-crop, crop:-crop]
-                ),
-                axis=(-4, -3, -2, -1),
-            )
-            position_update_denominator[lo:hi, ..., 1] = cp.sum(
-                cp.abs(
-                    grad_y[..., crop:-crop, crop:-crop]
-                    * unique_probe[..., crop:-crop, crop:-crop]
-                )
-                ** 2,
-                axis=(-4, -3, -2, -1),
-            )
+        #     position_update_numerator[lo:hi, ..., 0] = cp.sum(
+        #         cp.real(
+        #             cp.conj(
+        #                 grad_x[..., crop:-crop, crop:-crop]
+        #                 * unique_probe[..., crop:-crop, crop:-crop]
+        #             )
+        #             * diff[..., crop:-crop, crop:-crop]
+        #         ),
+        #         axis=(-4, -3, -2, -1),
+        #     )
+        #     position_update_denominator[lo:hi, ..., 0] = cp.sum(
+        #         cp.abs(
+        #             grad_x[..., crop:-crop, crop:-crop]
+        #             * unique_probe[..., crop:-crop, crop:-crop]
+        #         )
+        #         ** 2,
+        #         axis=(-4, -3, -2, -1),
+        #     )
+        #     position_update_numerator[lo:hi, ..., 1] = cp.sum(
+        #         cp.real(
+        #             cp.conj(
+        #                 grad_y[..., crop:-crop, crop:-crop]
+        #                 * unique_probe[..., crop:-crop, crop:-crop]
+        #             )
+        #             * diff[..., crop:-crop, crop:-crop]
+        #         ),
+        #         axis=(-4, -3, -2, -1),
+        #     )
+        #     position_update_denominator[lo:hi, ..., 1] = cp.sum(
+        #         cp.abs(
+        #             grad_y[..., crop:-crop, crop:-crop]
+        #             * unique_probe[..., crop:-crop, crop:-crop]
+        #         )
+        #         ** 2,
+        #         axis=(-4, -3, -2, -1),
+        #     )
 
     tike.communicators.stream.stream_and_modify2(
         f=keep_some_args_constant,
@@ -662,53 +561,52 @@ def _get_nearplane_gradients(
         bcosts,
         psi_update_numerator,
         probe_update_numerator,
-        multislice_probe_update_numerator,
         position_update_numerator,
         position_update_denominator,
         eigen_weights,
     )
 
 
-def _update_position(
-    scan: npt.NDArray,
-    position_options: PositionOptions,
-    position_update_numerator: npt.NDArray,
-    position_update_denominator: npt.NDArray,
-    *,
-    alpha: float = 0.05,
-    max_shift: float = 1.0,
-    epoch: int = 0,
-) -> typing.Tuple[cp.ndarray, PositionOptions]:
-    if epoch < position_options.update_start:
-        return scan, position_options
+# def _update_position(
+#     scan: npt.NDArray,
+#     position_options: PositionOptions,
+#     position_update_numerator: npt.NDArray,
+#     position_update_denominator: npt.NDArray,
+#     *,
+#     alpha: float = 0.05,
+#     max_shift: float = 1.0,
+#     epoch: int = 0,
+# ) -> typing.Tuple[cp.ndarray, PositionOptions]:
+#     if epoch < position_options.update_start:
+#         return scan, position_options
 
-    step = (position_update_numerator) / (
-        (1 - alpha) * position_update_denominator +
-        alpha * max(position_update_denominator.max(), 1e-6))
+#     step = (position_update_numerator) / (
+#         (1 - alpha) * position_update_denominator +
+#         alpha * max(position_update_denominator.max(), 1e-6))
 
-    if position_options.update_magnitude_limit > 0:
-        step = cp.clip(
-            step,
-            a_min=-position_options.update_magnitude_limit,
-            a_max=position_options.update_magnitude_limit,
-        )
+#     if position_options.update_magnitude_limit > 0:
+#         step = cp.clip(
+#             step,
+#             a_min=-position_options.update_magnitude_limit,
+#             a_max=position_options.update_magnitude_limit,
+#         )
 
-    # Remove outliars and subtract the mean
-    step = step - cupyx.scipy.stats.trim_mean(step, 0.05)
+#     # Remove outliars and subtract the mean
+#     step = step - cupyx.scipy.stats.trim_mean(step, 0.05)
 
-    if position_options.use_adaptive_moment:
-        (
-            step,
-            position_options.v,
-            position_options.m,
-        ) = tike.opt.adam(
-            step,
-            position_options.v,
-            position_options.m,
-            vdecay=position_options.vdecay,
-            mdecay=position_options.mdecay,
-        )
+#     if position_options.use_adaptive_moment:
+#         (
+#             step,
+#             position_options.v,
+#             position_options.m,
+#         ) = tike.opt.adam(
+#             step,
+#             position_options.v,
+#             position_options.m,
+#             vdecay=position_options.vdecay,
+#             mdecay=position_options.mdecay,
+#         )
 
-    scan -= step
+#     scan -= step
 
-    return scan, position_options
+#     return scan, position_options


### PR DESCRIPTION
## Purpose
(a) rPIE probe update is now strictly ePIE as the parameter which makes ePIE and rPIE different is irrelevant for the probe updates, (b) rPIE scan position correction has been commented out for now as it is incorrect and not effective, (c) renamed/removed some redundant variables in multislice rPIE

## Approach
I'll fix the rPIE scan position correction code later or simply remove it from rPIE and LSTSQ code so that both ptycho updates schemes for the sample/probe use the same scheme for scan position updates. Also, from a recent publication of mine that thoroughly benchmarks rPIE and ePIE, we concluded that for the probe updates that rPIE and ePIE are equally effective. Since ePIE is simpler to compute, we use this now for the probe updates (rPIE is still used for the sample updates).

## Pre-Merge Checklists

### Submitter
- [ ] Write a helpfully descriptive pull request title.
- [ ] Organize changes into logically grouped commits with descriptive commit messages.
- [ ] Document all new functions.
- [ ] Click 'details' on the readthedocs check to view the updated docs.
- [ ] Write tests for new functions or explain why they are not needed.
- [ ] Address any complaints from pep8speaks.

### Reviewer
- [ ] Actually read all of the code.
- [ ] Run the new code yourself; the included tests should make this easy.
- [ ] Write a summary of the changes as you understand them.
- [ ] Thank the submitter.
